### PR TITLE
build(docker): improve docker efficiency

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -4,7 +4,11 @@ on:
   push:
     branches:
       - "main"
-
+  # Test the image on PR's
+  pull_request:
+    branches:
+      - '*'    
+    
 jobs:
   docker:
     runs-on: ubuntu-latest
@@ -20,7 +24,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push
         uses: docker/build-push-action@v4
-        with:
-          push: true
+        with:          
+          push: ${{ github.event_name != 'pull_request' }}
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           tags: ${{ secrets.DOCKERHUB_USERNAME }}/home-assistant-streamdeck-yaml:latest

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - "main"
-  # Test the image on PR's
+  # Test the image on PRs
   pull_request:
     branches:
       - '*'    

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:alpine3.17
+FROM python:3.11-alpine3.17
 
 # Install dependencies
 RUN apk update && apk add --no-cache \
@@ -30,7 +30,7 @@ RUN mkdir -p /etc/udev/rules.d
 RUN echo 'SUBSYSTEMS=="usb", ATTRS{idVendor}=="0fd9", GROUP="users", TAG+="uaccess"' > /etc/udev/rules.d/99-streamdeck.rules
 
 # Clone the repository
-RUN git clone --depth 1 https://github.com/basnijholt/home-assistant-streamdeck-yaml.git /app
+COPY . /app
 
 # Set the working directory to the repository
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,6 @@ RUN apk update && apk add --no-cache \
     libusb-dev \
     hidapi-dev \
     libffi-dev \
-    # Needed for git clone
-    git \
     # Needed for cairosvg
     cairo-dev \
     # Needed for lxml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.11-alpine3.17
 
 # Install dependencies
-RUN apk update && apk add --no-cache \
+RUN apk --update --no-cache \
     # Stream Deck dependencies
     libusb \
     libusb-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,19 +30,17 @@ RUN mkdir -p /etc/udev/rules.d
 RUN echo 'SUBSYSTEMS=="usb", ATTRS{idVendor}=="0fd9", GROUP="users", TAG+="uaccess"' > /etc/udev/rules.d/99-streamdeck.rules
 
 # Clone the repository
-RUN git clone https://github.com/basnijholt/home-assistant-streamdeck-yaml.git /app
+RUN git clone --depth 1 https://github.com/basnijholt/home-assistant-streamdeck-yaml.git /app
 
 # Set the working directory to the repository
 WORKDIR /app
 
 # Install the required dependencies
-RUN pip3 install -e ".[colormap]"
-
-# Remove musl-dev and gcc
-RUN apk del build-deps && rm -rf /var/cache/apk/*
-
-# Purge the pip cache
-RUN pip3 cache purge
+RUN pip3 install -e ".[colormap]" && \
+    # Remove musl-dev and gcc
+    apk del build-deps && rm -rf /var/cache/apk/* && \
+    # Purge the pip cache
+    pip3 cache purge
 
 # Set the entrypoint to run the application
 ENTRYPOINT ["/bin/sh", "-c", "home-assistant-streamdeck-yaml"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.11-alpine3.17
 
 # Install dependencies
-RUN apk --update --no-cache \
+RUN apk --update --no-cache add \
     # Stream Deck dependencies
     libusb \
     libusb-dev \
@@ -34,11 +34,9 @@ COPY . /app
 WORKDIR /app
 
 # Install the required dependencies
-RUN pip3 install -e ".[colormap]" && \
+RUN pip3 install -e ".[colormap]" --no-cache-dir && \
     # Remove musl-dev and gcc
     apk del build-deps && rm -rf /var/cache/apk/* && \
-    # Purge the pip cache
-    pip3 cache purge
 
 # Set the entrypoint to run the application
 ENTRYPOINT ["/bin/sh", "-c", "home-assistant-streamdeck-yaml"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,28 +16,31 @@ RUN apk --update --no-cache add \
     # Openblas for Matplotlib (numpy)
     openblas-dev \
     # Needed for pip install
-    && apk add --virtual build-deps \
+    && apk add --no-cache --virtual build-deps \
     # General
     gcc python3-dev musl-dev \
     # Needed for matplotlib
-    g++ gfortran py-pip build-base wget \
-    && rm -rf /var/cache/apk/*
+    g++ gfortran py-pip build-base wget
 
 # Add udev rule for the Stream Deck
-RUN mkdir -p /etc/udev/rules.d
-RUN echo 'SUBSYSTEMS=="usb", ATTRS{idVendor}=="0fd9", GROUP="users", TAG+="uaccess"' > /etc/udev/rules.d/99-streamdeck.rules
-
-# Clone the repository
-COPY . /app
+RUN mkdir -p /etc/udev/rules.d && \
+    echo 'SUBSYSTEMS=="usb", ATTRS{idVendor}=="0fd9", GROUP="users", TAG+="uaccess"' > /etc/udev/rules.d/99-streamdeck.rules
 
 # Set the working directory to the repository
 WORKDIR /app
+
+# Copy the dependencies file for pip
+COPY pyproject.toml /app/
 
 # Install the required dependencies
 RUN pip3 install -e ".[colormap]" --no-cache-dir && \
     # Remove musl-dev and gcc
     apk del build-deps && \
     rm -rf /var/cache/apk/*
+
+# Copy the rest of the files
+# This is done after the pip install to make sure that the dependencies are cached
+COPY . /app
 
 # Set the entrypoint to run the application
 ENTRYPOINT ["/bin/sh", "-c", "home-assistant-streamdeck-yaml"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,8 @@ WORKDIR /app
 # Install the required dependencies
 RUN pip3 install -e ".[colormap]" --no-cache-dir && \
     # Remove musl-dev and gcc
-    apk del build-deps && rm -rf /var/cache/apk/* && \
+    apk del build-deps && \
+    rm -rf /var/cache/apk/*
 
 # Set the entrypoint to run the application
 ENTRYPOINT ["/bin/sh", "-c", "home-assistant-streamdeck-yaml"]


### PR DESCRIPTION
This improves the Dockerfile and general CI on these points:
- Use a versioned image to make sure that the python versioned targeted is supported
- Test the building of images in PRs
- Combine RUN commands into single layers. This decreases the resulting image size.
- COPY the code instead of cloning. This is more efficient and won't include git history.
- COPY the requirements first, so that the image is cached when the project changes