### PR TITLE
fix: support `states(state, with_unit=True)` for numeric states

### DIFF
--- a/home_assistant_streamdeck_yaml.py
+++ b/home_assistant_streamdeck_yaml.py
@@ -1211,7 +1211,7 @@ def _states(
     if with_unit:
         unit = entity_state.get("attributes", {}).get("unit_of_measurement")
         if unit:
-            state += f" {unit}"
+            state = f"{state} {unit}"
     return state
 
 


### PR DESCRIPTION
For numeric types there's a mismatch for `[number] += [string]`, which throws an error.

In this change, we don't coerce the result to a string above so other templates can continue to use the numeric response.