### PR TITLE
Disable console.log(state_dict)

### DIFF
--- a/home_assistant_streamdeck_yaml.py
+++ b/home_assistant_streamdeck_yaml.py
@@ -1282,7 +1282,6 @@ async def get_states(websocket: websockets.WebSocketClientProtocol) -> dict[str,
         if data["type"] == "result":
             # Extract the state data from the response
             state_dict = {state["entity_id"]: state for state in data["result"]}
-            console.log(state_dict)
             return state_dict
 
 

--- a/home_assistant_streamdeck_yaml.py
+++ b/home_assistant_streamdeck_yaml.py
@@ -1281,8 +1281,7 @@ async def get_states(websocket: websockets.WebSocketClientProtocol) -> dict[str,
         data = json.loads(await websocket.recv())
         if data["type"] == "result":
             # Extract the state data from the response
-            state_dict = {state["entity_id"]: state for state in data["result"]}
-            return state_dict
+            return {state["entity_id"]: state for state in data["result"]}
 
 
 async def unsubscribe(websocket: websockets.WebSocketClientProtocol, id_: int) -> None:


### PR DESCRIPTION
This PR is removing console.log(state_dict) which happens at start. 
For my installation it is just too much data to output, and it takes too long to show this in console, in meantime websocket connection is dropped. 