### PR TITLE
Sync state entity back to HA, support for setting brightness from HA

### DIFF
--- a/home_assistant_streamdeck_yaml.py
+++ b/home_assistant_streamdeck_yaml.py
@@ -1526,7 +1526,7 @@ async def _handle_key_press(
 ) -> None:
     if not config._is_on:
         turn_on(config, deck, complete_state)
-        if config.state_entity_id is not None:
+        if config.state_entity_id is not None and config.state_entity_id.startswith("input_boolean"):
             service_data = {}
             service_data["entity_id"] = config.state_entity_id
             await call_service(websocket, "input_boolean.turn_on", service_data)
@@ -1549,7 +1549,7 @@ async def _handle_key_press(
         return  # to skip the _detached_page reset below
     elif button.special_type == "turn-off":
         turn_off(config, deck)
-        if config.state_entity_id is not None:
+        if config.state_entity_id is not None and config.state_entity_id.startswith("input_boolean"):
             service_data = {}
             service_data["entity_id"] = config.state_entity_id
             await call_service(websocket, "input_boolean.turn_off", service_data)
@@ -1848,11 +1848,12 @@ async def run(
     async with setup_ws(host, token, protocol) as websocket:
         complete_state = await get_states(websocket)
 
-        is_off = complete_state[config.state_entity_id]["state"] == "off"
-        if is_off:
-            turn_off(config, deck)
-        else:
-            deck.set_brightness(config.brightness)
+        deck.set_brightness(config.brightness)
+
+        if config.state_entity_id is not None:
+            is_off = complete_state[config.state_entity_id]["state"] == "off"
+            if is_off:
+                turn_off(config, deck)
 
         update_all_key_images(deck, config, complete_state)
         deck.set_key_callback_async(

--- a/home_assistant_streamdeck_yaml.py
+++ b/home_assistant_streamdeck_yaml.py
@@ -1526,6 +1526,10 @@ async def _handle_key_press(
 ) -> None:
     if not config._is_on:
         turn_on(config, deck, complete_state)
+        if config.state_entity_id is not None:
+            service_data = {}
+            service_data["entity_id"] = config.state_entity_id
+            await call_service(websocket, "input_boolean.turn_on", service_data)
         return
 
     def update_all() -> None:
@@ -1545,6 +1549,10 @@ async def _handle_key_press(
         return  # to skip the _detached_page reset below
     elif button.special_type == "turn-off":
         turn_off(config, deck)
+        if config.state_entity_id is not None:
+            service_data = {}
+            service_data["entity_id"] = config.state_entity_id
+            await call_service(websocket, "input_boolean.turn_off", service_data)
     elif button.special_type == "light-control":
         assert isinstance(button.special_type_data, dict)
         page = _light_page(

--- a/home_assistant_streamdeck_yaml.py
+++ b/home_assistant_streamdeck_yaml.py
@@ -1847,6 +1847,13 @@ async def run(
     deck = get_deck()
     async with setup_ws(host, token, protocol) as websocket:
         complete_state = await get_states(websocket)
+
+        is_off = complete_state[config.state_entity_id]["state"] == "off"
+        if is_off:
+            turn_off(config, deck)
+        else:
+            deck.set_brightness(config.brightness)
+
         update_all_key_images(deck, config, complete_state)
         deck.set_key_callback_async(
             _on_press_callback(websocket, complete_state, config),


### PR DESCRIPTION
Right now state_entity_id is working one way, if you toggle input_boolean switch in HA then streamdeck will turn off/on. 
However, pressing any key on streamdeck doesn't turn it back in HA, this PR adds this missing functionality.

I added also here  brightness_entity_id which allows to alter default brightness set in config from HA. 
