### PR TITLE
Adding 2-way sync (SD-to-HAss) for state_entity_id

### DIFF
--- a/home_assistant_streamdeck_yaml.py
+++ b/home_assistant_streamdeck_yaml.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Home Assistant Stream Deck integration."""
+
 from __future__ import annotations
 
 import asyncio
@@ -1520,6 +1521,23 @@ def turn_off(config: Config, deck: StreamDeck) -> None:
     deck.set_brightness(0)
 
 
+async def _sync_input_boolean(
+    state_entity_id: str | None,
+    websocket: websockets.WebSocketClientProtocol,
+    state: Literal["on", "off"],
+) -> None:
+    """Sync the input boolean state with the Stream Deck."""
+    if (state_entity_id is not None) and (
+        state_entity_id.split(".")[0] == "input_boolean"
+    ):
+        await call_service(
+            websocket,
+            f"input_boolean.turn_{state}",
+            {},
+            {"entity_id": state_entity_id},
+        )
+
+
 async def _handle_key_press(
     websocket: websockets.WebSocketClientProtocol,
     complete_state: StateDict,
@@ -1529,16 +1547,7 @@ async def _handle_key_press(
 ) -> None:
     if not config._is_on:
         turn_on(config, deck, complete_state)
-        if (config.state_entity_id is not None) and (
-            config.state_entity_id.split(".")[0] == "input_boolean"
-        ):
-            await call_service(
-                websocket,
-                "input_boolean.turn_on",
-                {},
-                {"entity_id": config.state_entity_id},
-            )
-        return
+        await _sync_input_boolean(config.state_entity_id, websocket, "on")
 
     def update_all() -> None:
         deck.reset()
@@ -1557,15 +1566,7 @@ async def _handle_key_press(
         return  # to skip the _detached_page reset below
     elif button.special_type == "turn-off":
         turn_off(config, deck)
-        if (config.state_entity_id is not None) and (
-            config.state_entity_id.split(".")[0] == "input_boolean"
-        ):
-            await call_service(
-                websocket,
-                "input_boolean.turn_off",
-                {},
-                {"entity_id": config.state_entity_id},
-            )
+        await _sync_input_boolean(config.state_entity_id, websocket, "off")
     elif button.special_type == "light-control":
         assert isinstance(button.special_type_data, dict)
         page = _light_page(

--- a/home_assistant_streamdeck_yaml.py
+++ b/home_assistant_streamdeck_yaml.py
@@ -1529,6 +1529,8 @@ async def _handle_key_press(
 ) -> None:
     if not config._is_on:
         turn_on(config, deck, complete_state)
+        if (config.state_entity_id is not None) and (config.state_entity_id.split(".")[0] == "input_boolean"):
+            call_service(websocket, "input_boolean.turn_on", {}, {"entity_id": config.state_entity_id})
         return
 
     def update_all() -> None:
@@ -1548,6 +1550,8 @@ async def _handle_key_press(
         return  # to skip the _detached_page reset below
     elif button.special_type == "turn-off":
         turn_off(config, deck)
+        if (config.state_entity_id is not None) and (config.state_entity_id.split(".")[0] == "input_boolean"):
+            call_service(websocket, "input_boolean.turn_off", {}, {"entity_id": config.state_entity_id})
     elif button.special_type == "light-control":
         assert isinstance(button.special_type_data, dict)
         page = _light_page(

--- a/home_assistant_streamdeck_yaml.py
+++ b/home_assistant_streamdeck_yaml.py
@@ -1529,8 +1529,15 @@ async def _handle_key_press(
 ) -> None:
     if not config._is_on:
         turn_on(config, deck, complete_state)
-        if (config.state_entity_id is not None) and (config.state_entity_id.split(".")[0] == "input_boolean"):
-            await call_service(websocket, "input_boolean.turn_on", {}, {"entity_id": config.state_entity_id})
+        if (config.state_entity_id is not None) and (
+            config.state_entity_id.split(".")[0] == "input_boolean"
+        ):
+            await call_service(
+                websocket,
+                "input_boolean.turn_on",
+                {},
+                {"entity_id": config.state_entity_id},
+            )
         return
 
     def update_all() -> None:
@@ -1550,8 +1557,15 @@ async def _handle_key_press(
         return  # to skip the _detached_page reset below
     elif button.special_type == "turn-off":
         turn_off(config, deck)
-        if (config.state_entity_id is not None) and (config.state_entity_id.split(".")[0] == "input_boolean"):
-            await call_service(websocket, "input_boolean.turn_off", {}, {"entity_id": config.state_entity_id})
+        if (config.state_entity_id is not None) and (
+            config.state_entity_id.split(".")[0] == "input_boolean"
+        ):
+            await call_service(
+                websocket,
+                "input_boolean.turn_off",
+                {},
+                {"entity_id": config.state_entity_id},
+            )
     elif button.special_type == "light-control":
         assert isinstance(button.special_type_data, dict)
         page = _light_page(

--- a/home_assistant_streamdeck_yaml.py
+++ b/home_assistant_streamdeck_yaml.py
@@ -1530,7 +1530,7 @@ async def _handle_key_press(
     if not config._is_on:
         turn_on(config, deck, complete_state)
         if (config.state_entity_id is not None) and (config.state_entity_id.split(".")[0] == "input_boolean"):
-            call_service(websocket, "input_boolean.turn_on", {}, {"entity_id": config.state_entity_id})
+            await call_service(websocket, "input_boolean.turn_on", {}, {"entity_id": config.state_entity_id})
         return
 
     def update_all() -> None:
@@ -1551,7 +1551,7 @@ async def _handle_key_press(
     elif button.special_type == "turn-off":
         turn_off(config, deck)
         if (config.state_entity_id is not None) and (config.state_entity_id.split(".")[0] == "input_boolean"):
-            call_service(websocket, "input_boolean.turn_off", {}, {"entity_id": config.state_entity_id})
+            await call_service(websocket, "input_boolean.turn_off", {}, {"entity_id": config.state_entity_id})
     elif button.special_type == "light-control":
         assert isinstance(button.special_type_data, dict)
         page = _light_page(


### PR DESCRIPTION
Basic skeleton for updating the `state_entity_id` in HAss when the streamdeck is manually turned on or off.

For now, I am only doing this if the `state_entity_id` is an `input_boolean`. In the future, I would like to make this configurable by adding another global config setting (e.g. `state_bidirectional_sync`). 

But before moving forward, basnijholt needs to confirm I didn't manage to break anything :)