### PR TITLE
Add close page button

### DIFF
--- a/home_assistant_streamdeck_yaml.py
+++ b/home_assistant_streamdeck_yaml.py
@@ -817,7 +817,10 @@ class Page(BaseModel):
 
 class Config(BaseModel):
     """Configuration file."""
-
+    yaml_encoding: str = Field(
+        default="utf-8",
+        description="The encoding of the YAML file.",
+    )
     pages: list[Page] = Field(
         default_factory=list,
         description="A list of `Page`s in the configuration.",
@@ -867,7 +870,7 @@ class Config(BaseModel):
         """Reload the configuration file."""
         assert self._configuration_file is not None
         # Updates all public attributes
-        new_config = self.load(self._configuration_file)
+        new_config = self.load(self._configuration_file, yaml_encoding=self.yaml_encoding)
         self.__dict__.update(new_config.__dict__)
         self._include_files = new_config._include_files
         # Set the private attributes we want to preserve

--- a/home_assistant_streamdeck_yaml.py
+++ b/home_assistant_streamdeck_yaml.py
@@ -1267,7 +1267,7 @@ def _light_page(
     n_colors: int,
     colors: tuple[str, ...] | None,
     color_temp_kelvin: tuple[int, ...] | None,
-    brightness: tuple[int, ...],
+    brightness: tuple[int, ...] | None,
     colormap: str | None,
 ) -> Page:
     """Return a page of buttons for controlling lights."""

--- a/home_assistant_streamdeck_yaml.py
+++ b/home_assistant_streamdeck_yaml.py
@@ -851,10 +851,10 @@ class Config(BaseModel):
     _include_files: list[Path] = PrivateAttr(default_factory=list)
 
     @classmethod
-    def load(cls: type[Config], fname: Path, encoding) -> Config:
+    def load(cls: type[Config], fname: Path, yaml_encoding) -> Config:
         """Read the configuration file."""
         with fname.open() as f:
-            data, include_files = safe_load_yaml(f, return_included_paths=True, encoding=encoding)
+            data, include_files = safe_load_yaml(f, return_included_paths=True, encoding=yaml_encoding)
             config = cls(**data)  # type: ignore[arg-type]
             config._configuration_file = fname
             config._include_files = include_files
@@ -2582,7 +2582,7 @@ def main() -> None:
         type=Path,
     )
     parser.add_argument(
-        "--encoding",
+        "--yaml-encoding",
         default=yaml_encoding,
         help=f"Specify encoding for YAML files (default is system encoding or from environment variable YAML_ENCODING (default: {yaml_encoding})",
     )
@@ -2597,7 +2597,7 @@ def main() -> None:
     console.log(
         f"Starting Stream Deck integration with {args.host=}, {args.config=}, {args.protocol=}",
     )
-    config = Config.load(args.config, encoding=args.encoding)
+    config = Config.load(args.config, yaml_encoding=args.yaml_encoding)
     asyncio.run(
         run(
             host=args.host,

--- a/home_assistant_streamdeck_yaml.py
+++ b/home_assistant_streamdeck_yaml.py
@@ -231,6 +231,7 @@ class Button(_ButtonDialBase, extra="forbid"):  # type: ignore[call-arg]
             "previous-page",
             "empty",
             "go-to-page",
+            "close-page",
             "turn-off",
             "light-control",
             "reload",
@@ -245,6 +246,7 @@ class Button(_ButtonDialBase, extra="forbid"):  # type: ignore[call-arg]
         " If `previous-page`, the button will go to the previous page."
         " If `turn-off`, the button will turn off the SteamDeck until any button is pressed."
         " If `empty`, the button will be empty."
+        " If `close-page`, the button will close the current page and return to the previous one."
         " If `go-to-page`, the button will go to the page specified by `special_type_data`"
         " (either an `int` or `str` (name of the page))."
         " If `light-control`, the button will control a light, and the `special_type_data`"
@@ -368,6 +370,9 @@ class Button(_ButtonDialBase, extra="forbid"):  # type: ignore[call-arg]
             page = button.special_type_data
             text = button.text or f"Go to\nPage\n{page}"
             icon_mdi = button.icon_mdi or "book-open-page-variant"
+        elif button.special_type == "close-page":
+            text = button.text or "Close\nPage"
+            icon_mdi = button.icon_mdi or "arrow-u-left-bottom-bold"
         elif button.special_type == "turn-off":
             text = button.text or "Turn off"
             icon_mdi = button.icon_mdi or "power"
@@ -774,6 +779,8 @@ class Page(BaseModel):
         description="A list of dials on the page.",
     )
 
+    _parent_page_index: int = PrivateAttr([])
+
     _dials_sorted: list[Dial] = PrivateAttr([])
 
     def sort_dials(self) -> list[tuple[Dial, Dial | None]]:
@@ -849,6 +856,7 @@ class Config(BaseModel):
         " be reloaded when it is modified.",
     )
     _current_page_index: int = PrivateAttr(default=0)
+    _parent_page_index: int = PrivateAttr(default=0)
     _is_on: bool = PrivateAttr(default=True)
     _detached_page: Page | None = PrivateAttr(default=None)
     _configuration_file: Path | None = PrivateAttr(default=None)
@@ -916,6 +924,7 @@ class Config(BaseModel):
 
     def next_page(self) -> Page:
         """Go to the next page."""
+        self._parent_page_index = self._current_page_index
         self._current_page_index = self.next_page_index
         return self.pages[self._current_page_index]
 
@@ -931,6 +940,7 @@ class Config(BaseModel):
 
     def previous_page(self) -> Page:
         """Go to the previous page."""
+        self._parent_page_index = self._current_page_index
         self._current_page_index = self.previous_page_index
         return self.pages[self._current_page_index]
 
@@ -964,6 +974,7 @@ class Config(BaseModel):
     def to_page(self, page: int | str) -> Page:
         """Go to a page based on the page name or index."""
         if isinstance(page, int):
+            self._parent_page_index = self._current_page_index
             self._current_page_index = page
             return self.current_page()
 
@@ -978,7 +989,12 @@ class Config(BaseModel):
                 return p
         console.log(f"Could find page {page}, staying on current page")
         return self.current_page()
-
+    
+    def close_page(self) -> Page:
+        """Close the current page."""
+        self._detached_page = None
+        self._current_page_index = self._parent_page_index
+        return self.current_page()
 
 def _next_id() -> int:
     global _ID_COUNTER
@@ -2154,6 +2170,9 @@ async def _handle_key_press(
     elif button.special_type == "previous-page":
         config.previous_page()
         update_all()
+    elif button.special_type == "close-page":
+        config.close_page()
+        update_all()    
     elif button.special_type == "go-to-page":
         assert isinstance(button.special_type_data, (str, int))
         config.to_page(button.special_type_data)  # type: ignore[arg-type]

--- a/home_assistant_streamdeck_yaml.py
+++ b/home_assistant_streamdeck_yaml.py
@@ -269,7 +269,9 @@ class Button(_ButtonDialBase, extra="forbid"):  # type: ignore[call-arg]
     )
 
     @classmethod
-    def from_yaml(cls: type[Button], yaml_str: str, encoding : str | None = None) -> Button:
+    def from_yaml(
+        cls: type[Button], yaml_str: str, encoding: str | None = None,
+    ) -> Button:
         """Set the attributes from a YAML string."""
         data = safe_load_yaml(yaml_str, encoding=encoding)
         return cls(**data[0])
@@ -833,7 +835,6 @@ class Page(BaseModel):
 class Config(BaseModel):
     """Configuration file."""
 
-
     yaml_encoding: str | None = Field(
         default="utf-8",
         description="The encoding of the YAML file.",
@@ -872,7 +873,9 @@ class Config(BaseModel):
     _include_files: list[Path] = PrivateAttr(default_factory=list)
 
     @classmethod
-    def load(cls: type[Config], fname: Path, yaml_encoding: str | None = None) -> Config:
+    def load(
+        cls: type[Config], fname: Path, yaml_encoding: str | None = None,
+    ) -> Config:
         """Read the configuration file."""
         with fname.open() as f:
             data, include_files = safe_load_yaml(
@@ -891,7 +894,8 @@ class Config(BaseModel):
         assert self._configuration_file is not None
         # Updates all public attributes
         new_config = self.load(
-            self._configuration_file, yaml_encoding=self.yaml_encoding,
+            self._configuration_file,
+            yaml_encoding=self.yaml_encoding,
         )
         self.__dict__.update(new_config.__dict__)
         self._include_files = new_config._include_files

--- a/home_assistant_streamdeck_yaml.py
+++ b/home_assistant_streamdeck_yaml.py
@@ -851,7 +851,7 @@ class Config(BaseModel):
     _include_files: list[Path] = PrivateAttr(default_factory=list)
 
     @classmethod
-    def load(cls: type[Config], fname: Path, yaml_encoding) -> Config:
+    def load(cls: type[Config], fname: Path, yaml_encoding: str) -> Config:
         """Read the configuration file."""
         with fname.open() as f:
             data, include_files = safe_load_yaml(f, return_included_paths=True, encoding=yaml_encoding)

--- a/home_assistant_streamdeck_yaml.py
+++ b/home_assistant_streamdeck_yaml.py
@@ -260,9 +260,10 @@ class Button(_ButtonDialBase, extra="forbid"):  # type: ignore[call-arg]
         " If `go-to-page`, the data should be an `int` or `str` (name of the page)."
         " If `light-control`, the data should optionally be a dictionary."
         " The dictionary can contain the following keys:"
-        " The `colors` key and a value a list of max (`n_keys_on_streamdeck - 5`) hex colors."
-        " The `color_temp_kelvin` key and a value a list of max (`n_keys_on_streamdeck - 5`) color temperatures in Kelvin."
+        " The `colors` key and a value a list of max (`n_keys_on_streamdeck - 6`) hex colors."
+        " The `color_temp_kelvin` key and a value a list of max (`n_keys_on_streamdeck - 6`) color temperatures in Kelvin."
         " The `colormap` key and a value a colormap (https://matplotlib.org/stable/tutorials/colors/colormaps.html)"
+        " The `brightness` key and a value a brightness level (0-100)."
         " can be used. This requires the `matplotlib` package to be installed. If no"
         " list of `colors` or `colormap` is specified, 10 equally spaced colors are used.",
     )
@@ -450,7 +451,7 @@ class Button(_ButtonDialBase, extra="forbid"):  # type: ignore[call-arg]
                 )
                 raise AssertionError(msg)
             # Can only have the following keys: colors and colormap
-            allowed_keys = {"colors", "colormap", "color_temp_kelvin"}
+            allowed_keys = {"colors", "colormap", "color_temp_kelvin", "brightness"}
             invalid_keys = v.keys() - allowed_keys
             if invalid_keys:
                 msg = (
@@ -475,6 +476,13 @@ class Button(_ButtonDialBase, extra="forbid"):  # type: ignore[call-arg]
                         raise AssertionError(msg)  # noqa: TRY004
                 # Cast color_temp_kelvin to tuple (to make it hashable)
                 v["color_temp_kelvin"] = tuple(v["color_temp_kelvin"])
+            if "brightness" in v:
+                for brightness in v["brightness"]:
+                    if not isinstance(brightness, int):
+                        msg = "All brightness must be integers"
+                        raise AssertionError(msg)  # noqa: TRY004
+                # Cast brightness to tuple (to make it hashable)
+                v["brightness"] = tuple(v["brightness"])
         return v
 
     def maybe_start_or_cancel_timer(
@@ -1259,6 +1267,7 @@ def _light_page(
     n_colors: int,
     colors: tuple[str, ...] | None,
     color_temp_kelvin: tuple[int, ...] | None,
+    brightness: tuple[int, ...],
     colormap: str | None,
 ) -> Page:
     """Return a page of buttons for controlling lights."""
@@ -1290,22 +1299,23 @@ def _light_page(
         for kelvin in (color_temp_kelvin or ())
     ]
     buttons_brightness = []
-    for brightness in [0, 10, 30, 60, 100]:
+    for brightness in brightness if brightness is not None else [0, 33, 66, 100]:
         background_color = _scale_hex_color("#FFFFFF", brightness / 100)
         button = Button(
             icon_background_color=background_color,
             service="light.turn_on",
             text_color=_max_contrast_color(background_color),
-            text=f"{brightness}%",
+            text=f"{brightness}%" if brightness >0 else "OFF",
             service_data={
                 "entity_id": entity_id,
                 "brightness_pct": brightness,
             },
         )
         buttons_brightness.append(button)
+    buttons_back = [Button(special_type="close-page")]
     return Page(
         name="Lights",
-        buttons=buttons_colors + buttons_color_temp_kelvin + buttons_brightness,
+        buttons=buttons_colors + buttons_color_temp_kelvin + buttons_brightness + buttons_back,
     )
 
 
@@ -2185,10 +2195,11 @@ async def _handle_key_press(
         assert isinstance(button.special_type_data, dict)
         page = _light_page(
             entity_id=button.entity_id,
-            n_colors=10,
+            n_colors=9,
             colormap=button.special_type_data.get("colormap", None),
             colors=button.special_type_data.get("colors", None),
             color_temp_kelvin=button.special_type_data.get("color_temp_kelvin", None),
+            brightness=button.special_type_data.get("brightness", None),
         )
         config._detached_page = page
         update_all()

--- a/home_assistant_streamdeck_yaml.py
+++ b/home_assistant_streamdeck_yaml.py
@@ -266,9 +266,9 @@ class Button(_ButtonDialBase, extra="forbid"):  # type: ignore[call-arg]
     )
 
     @classmethod
-    def from_yaml(cls: type[Button], yaml_str: str) -> Button:
+    def from_yaml(cls: type[Button], yaml_str: str, encoding : str | None = None) -> Button:
         """Set the attributes from a YAML string."""
-        data = safe_load_yaml(yaml_str)
+        data = safe_load_yaml(yaml_str, encoding=encoding)
         return cls(**data[0])
 
     @property
@@ -818,7 +818,7 @@ class Page(BaseModel):
 class Config(BaseModel):
     """Configuration file."""
 
-    yaml_encoding: str = Field(
+    yaml_encoding: str | None = Field(
         default="utf-8",
         description="The encoding of the YAML file.",
     )
@@ -855,7 +855,7 @@ class Config(BaseModel):
     _include_files: list[Path] = PrivateAttr(default_factory=list)
 
     @classmethod
-    def load(cls: type[Config], fname: Path, yaml_encoding: str) -> Config:
+    def load(cls: type[Config], fname: Path, yaml_encoding: str | None = None) -> Config:
         """Read the configuration file."""
         with fname.open() as f:
             data, include_files = safe_load_yaml(
@@ -2498,7 +2498,7 @@ def safe_load_yaml(
     f: TextIO | str,
     *,
     return_included_paths: bool = False,
-    encoding: str,
+    encoding: str | None = None,
 ) -> Any | tuple[Any, list]:
     """Load a YAML file."""
     included_files = []

--- a/home_assistant_streamdeck_yaml.py
+++ b/home_assistant_streamdeck_yaml.py
@@ -817,6 +817,7 @@ class Page(BaseModel):
 
 class Config(BaseModel):
     """Configuration file."""
+
     yaml_encoding: str = Field(
         default="utf-8",
         description="The encoding of the YAML file.",
@@ -872,7 +873,9 @@ class Config(BaseModel):
         """Reload the configuration file."""
         assert self._configuration_file is not None
         # Updates all public attributes
-        new_config = self.load(self._configuration_file, yaml_encoding=self.yaml_encoding)
+        new_config = self.load(
+            self._configuration_file, yaml_encoding=self.yaml_encoding,
+        )
         self.__dict__.update(new_config.__dict__)
         self._include_files = new_config._include_files
         # Set the private attributes we want to preserve

--- a/includes/home.yaml
+++ b/includes/home.yaml
@@ -17,6 +17,11 @@
       - 3521  # from default HA options
       - 5025  # from default HA options
       - 6535  # from default HA options
+    brightness:
+      - 0
+      - 10 
+      - 50 
+      - 100
 - special_type: go-to-page
   special_type_data: all-lights
   text: |

--- a/includes/testing.yaml
+++ b/includes/testing.yaml
@@ -56,6 +56,6 @@
   special_type_data: bas
 - special_type: empty
 - special_type: empty
-- special_type: empty
+- special_type: close-page
 - special_type: previous-page
 - special_type: next-page

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -218,6 +218,7 @@ def test_example_config_browsing_pages(config: Config) -> None:
     assert config._current_page_index == 0
     assert config.button(0) == first_page.buttons[0]
 
+
 def test_example_close_pages(config: Config) -> None:
     """Test example config close pages."""
     assert isinstance(config, Config)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -97,7 +97,6 @@ def button_dict() -> dict[str, dict[str, Any]]:
                     "#FFD700",  # gold
                     "#008000",  # dark green
                 ],
-                "brightness": [0, 10, 50, 100],
             },
         },
         "icon_from_url": {

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -225,7 +225,7 @@ def test_example_close_pages(config: Config) -> None:
     second_page = config.next_page()
     assert isinstance(second_page, Page)
     assert config._current_page_index == 1
-    config.close_pages()
+    config.close_page()
     assert config._current_page_index == 0
 
 
@@ -435,6 +435,7 @@ def test_light_page() -> None:
         colormap="hsv",
         colors=None,
         color_temp_kelvin=None,
+        brightness=None,
     )
     buttons = page.buttons
     assert len(buttons) == BUTTONS_PER_PAGE

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -97,6 +97,7 @@ def button_dict() -> dict[str, dict[str, Any]]:
                     "#FFD700",  # gold
                     "#008000",  # dark green
                 ],
+                "brightness": [0, 10, 50, 100],
             },
         },
         "icon_from_url": {
@@ -217,6 +218,16 @@ def test_example_config_browsing_pages(config: Config) -> None:
     first_page = config.to_page(first_page.name)
     assert config._current_page_index == 0
     assert config.button(0) == first_page.buttons[0]
+
+def test_example_close_pages(config: Config) -> None:
+    """Test example config close pages."""
+    assert isinstance(config, Config)
+    assert config._current_page_index == 0
+    second_page = config.next_page()
+    assert isinstance(second_page, Page)
+    assert config._current_page_index == 1
+    config.close_pages()
+    assert config._current_page_index == 0
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
Add a button to close pages, mostly in case a button is pressed by mistake.

Currently, due to light-control requiring a button to be clicked, one is forced to select one of the options on the light page.
This allows one to close the page, which is useful if opened by mistake, or for demo purposes.

This is further tested in a subsequent feature (light-page-tweaks)