### PR TITLE
Fix default config loading for windows

### DIFF
--- a/home_assistant_streamdeck_yaml.py
+++ b/home_assistant_streamdeck_yaml.py
@@ -266,7 +266,9 @@ class Button(_ButtonDialBase, extra="forbid"):  # type: ignore[call-arg]
     )
 
     @classmethod
-    def from_yaml(cls: type[Button], yaml_str: str, encoding : str | None = None) -> Button:
+    def from_yaml(
+        cls: type[Button], yaml_str: str, encoding: str | None = None,
+    ) -> Button:
         """Set the attributes from a YAML string."""
         data = safe_load_yaml(yaml_str, encoding=encoding)
         return cls(**data[0])
@@ -855,7 +857,9 @@ class Config(BaseModel):
     _include_files: list[Path] = PrivateAttr(default_factory=list)
 
     @classmethod
-    def load(cls: type[Config], fname: Path, yaml_encoding: str | None = None) -> Config:
+    def load(
+        cls: type[Config], fname: Path, yaml_encoding: str | None = None,
+    ) -> Config:
         """Read the configuration file."""
         with fname.open() as f:
             data, include_files = safe_load_yaml(
@@ -874,7 +878,8 @@ class Config(BaseModel):
         assert self._configuration_file is not None
         # Updates all public attributes
         new_config = self.load(
-            self._configuration_file, yaml_encoding=self.yaml_encoding,
+            self._configuration_file,
+            yaml_encoding=self.yaml_encoding,
         )
         self.__dict__.update(new_config.__dict__)
         self._include_files = new_config._include_files

--- a/home_assistant_streamdeck_yaml.py
+++ b/home_assistant_streamdeck_yaml.py
@@ -817,7 +817,10 @@ class Page(BaseModel):
 
 class Config(BaseModel):
     """Configuration file."""
-
+    yaml_encoding: str = Field(
+        default="utf-8",
+        description="The encoding of the YAML file.",
+    )
     pages: list[Page] = Field(
         default_factory=list,
         description="A list of `Page`s in the configuration.",
@@ -867,7 +870,7 @@ class Config(BaseModel):
         """Reload the configuration file."""
         assert self._configuration_file is not None
         # Updates all public attributes
-        new_config = self.load(self._configuration_file)
+        new_config = self.load(self._configuration_file, yaml_encoding=self.yaml_encoding)
         self.__dict__.update(new_config.__dict__)
         self._include_files = new_config._include_files
         # Set the private attributes we want to preserve

--- a/home_assistant_streamdeck_yaml.py
+++ b/home_assistant_streamdeck_yaml.py
@@ -851,10 +851,10 @@ class Config(BaseModel):
     _include_files: list[Path] = PrivateAttr(default_factory=list)
 
     @classmethod
-    def load(cls: type[Config], fname: Path, encoding) -> Config:
+    def load(cls: type[Config], fname: Path, yaml_encoding) -> Config:
         """Read the configuration file."""
         with fname.open() as f:
-            data, include_files = safe_load_yaml(f, return_included_paths=True, encoding=encoding)
+            data, include_files = safe_load_yaml(f, return_included_paths=True, encoding=yaml_encoding)
             config = cls(**data)  # type: ignore[arg-type]
             config._configuration_file = fname
             config._include_files = include_files
@@ -2582,7 +2582,7 @@ def main() -> None:
         type=Path,
     )
     parser.add_argument(
-        "--encoding",
+        "--yaml-encoding",
         default=yaml_encoding,
         help=f"Specify encoding for YAML files (default is system encoding or from environment variable YAML_ENCODING (default: {yaml_encoding})",
     )
@@ -2597,7 +2597,7 @@ def main() -> None:
     console.log(
         f"Starting Stream Deck integration with {args.host=}, {args.config=}, {args.protocol=}",
     )
-    config = Config.load(args.config, encoding=args.encoding)
+    config = Config.load(args.config, yaml_encoding=args.yaml_encoding)
     asyncio.run(
         run(
             host=args.host,

--- a/home_assistant_streamdeck_yaml.py
+++ b/home_assistant_streamdeck_yaml.py
@@ -851,7 +851,7 @@ class Config(BaseModel):
     _include_files: list[Path] = PrivateAttr(default_factory=list)
 
     @classmethod
-    def load(cls: type[Config], fname: Path, yaml_encoding) -> Config:
+    def load(cls: type[Config], fname: Path, yaml_encoding: str) -> Config:
         """Read the configuration file."""
         with fname.open() as f:
             data, include_files = safe_load_yaml(f, return_included_paths=True, encoding=yaml_encoding)

--- a/home_assistant_streamdeck_yaml.py
+++ b/home_assistant_streamdeck_yaml.py
@@ -266,9 +266,9 @@ class Button(_ButtonDialBase, extra="forbid"):  # type: ignore[call-arg]
     )
 
     @classmethod
-    def from_yaml(cls: type[Button], yaml_str: str) -> Button:
+    def from_yaml(cls: type[Button], yaml_str: str, encoding : str | None = None) -> Button:
         """Set the attributes from a YAML string."""
-        data = safe_load_yaml(yaml_str)
+        data = safe_load_yaml(yaml_str, encoding=encoding)
         return cls(**data[0])
 
     @property
@@ -818,7 +818,7 @@ class Page(BaseModel):
 class Config(BaseModel):
     """Configuration file."""
 
-    yaml_encoding: str = Field(
+    yaml_encoding: str | None = Field(
         default="utf-8",
         description="The encoding of the YAML file.",
     )
@@ -855,7 +855,7 @@ class Config(BaseModel):
     _include_files: list[Path] = PrivateAttr(default_factory=list)
 
     @classmethod
-    def load(cls: type[Config], fname: Path, yaml_encoding: str) -> Config:
+    def load(cls: type[Config], fname: Path, yaml_encoding: str | None = None) -> Config:
         """Read the configuration file."""
         with fname.open() as f:
             data, include_files = safe_load_yaml(
@@ -2498,7 +2498,7 @@ def safe_load_yaml(
     f: TextIO | str,
     *,
     return_included_paths: bool = False,
-    encoding: str,
+    encoding: str | None = None,
 ) -> Any | tuple[Any, list]:
     """Load a YAML file."""
     included_files = []

--- a/home_assistant_streamdeck_yaml.py
+++ b/home_assistant_streamdeck_yaml.py
@@ -267,7 +267,9 @@ class Button(_ButtonDialBase, extra="forbid"):  # type: ignore[call-arg]
 
     @classmethod
     def from_yaml(
-        cls: type[Button], yaml_str: str, encoding: str | None = None,
+        cls: type[Button],
+        yaml_str: str,
+        encoding: str | None = None,
     ) -> Button:
         """Set the attributes from a YAML string."""
         data = safe_load_yaml(yaml_str, encoding=encoding)
@@ -858,7 +860,9 @@ class Config(BaseModel):
 
     @classmethod
     def load(
-        cls: type[Config], fname: Path, yaml_encoding: str | None = None,
+        cls: type[Config],
+        fname: Path,
+        yaml_encoding: str | None = None,
     ) -> Config:
         """Read the configuration file."""
         with fname.open() as f:

--- a/home_assistant_streamdeck_yaml.py
+++ b/home_assistant_streamdeck_yaml.py
@@ -817,6 +817,7 @@ class Page(BaseModel):
 
 class Config(BaseModel):
     """Configuration file."""
+
     yaml_encoding: str = Field(
         default="utf-8",
         description="The encoding of the YAML file.",
@@ -872,7 +873,9 @@ class Config(BaseModel):
         """Reload the configuration file."""
         assert self._configuration_file is not None
         # Updates all public attributes
-        new_config = self.load(self._configuration_file, yaml_encoding=self.yaml_encoding)
+        new_config = self.load(
+            self._configuration_file, yaml_encoding=self.yaml_encoding,
+        )
         self.__dict__.update(new_config.__dict__)
         self._include_files = new_config._include_files
         # Set the private attributes we want to preserve

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -218,6 +218,7 @@ def test_example_config_browsing_pages(config: Config) -> None:
     assert config._current_page_index == 0
     assert config.button(0) == first_page.buttons[0]
 
+
 def test_example_close_pages(config: Config) -> None:
     """Test example config close pages."""
     assert isinstance(config, Config)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -97,7 +97,6 @@ def button_dict() -> dict[str, dict[str, Any]]:
                     "#FFD700",  # gold
                     "#008000",  # dark green
                 ],
-                "brightness": [0, 10, 50, 100],
             },
         },
         "icon_from_url": {

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -219,17 +219,6 @@ def test_example_config_browsing_pages(config: Config) -> None:
     assert config.button(0) == first_page.buttons[0]
 
 
-def test_example_close_pages(config: Config) -> None:
-    """Test example config close pages."""
-    assert isinstance(config, Config)
-    assert config._current_page_index == 0
-    second_page = config.next_page()
-    assert isinstance(second_page, Page)
-    assert config._current_page_index == 1
-    config.close_pages()
-    assert config._current_page_index == 0
-
-
 @pytest.mark.skipif(
     not IS_CONNECTED_TO_HOMEASSISTANT,
     reason="Not connected to Home Assistant",

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -97,6 +97,7 @@ def button_dict() -> dict[str, dict[str, Any]]:
                     "#FFD700",  # gold
                     "#008000",  # dark green
                 ],
+                "brightness": [0, 10, 50, 100],
             },
         },
         "icon_from_url": {
@@ -217,6 +218,16 @@ def test_example_config_browsing_pages(config: Config) -> None:
     first_page = config.to_page(first_page.name)
     assert config._current_page_index == 0
     assert config.button(0) == first_page.buttons[0]
+
+def test_example_close_pages(config: Config) -> None:
+    """Test example config close pages."""
+    assert isinstance(config, Config)
+    assert config._current_page_index == 0
+    second_page = config.next_page()
+    assert isinstance(second_page, Page)
+    assert config._current_page_index == 1
+    config.close_pages()
+    assert config._current_page_index == 0
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
The default config wasn't loading in windows, due to encoding issues (due to the heart emoji)

- Add a yaml_encoding command line argument and ENV variable.

Some tests fail, but they are the same tests failing in the main branch