### PR TITLE
Fix test config loading to specify YAML encoding

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -49,16 +49,16 @@ sys.path.append(str(ROOT))
 TEST_STATE_FILENAME = ROOT / "tests" / "state.json"
 IS_CONNECTED_TO_HOMEASSISTANT = False
 BUTTONS_PER_PAGE = 15
-
+DEFAULT_CONFIG_ENCODING = "utf-8"
 
 def test_load_config() -> None:
     """Test Config.load."""
-    Config.load(DEFAULT_CONFIG)
+    Config.load(DEFAULT_CONFIG, yaml_encoding=DEFAULT_CONFIG_ENCODING)
 
 
 def test_reload_config() -> None:
     """Test Config.load."""
-    c = Config.load(DEFAULT_CONFIG)
+    c = Config.load(DEFAULT_CONFIG, yaml_encoding=DEFAULT_CONFIG_ENCODING)
     c.pages = []
     assert c.pages == []
     c.reload()

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -51,6 +51,7 @@ IS_CONNECTED_TO_HOMEASSISTANT = False
 BUTTONS_PER_PAGE = 15
 DEFAULT_CONFIG_ENCODING = "utf-8"
 
+
 def test_load_config() -> None:
     """Test Config.load."""
     Config.load(DEFAULT_CONFIG, yaml_encoding=DEFAULT_CONFIG_ENCODING)


### PR DESCRIPTION
Fix tests so that they can run on windows machines.

**Problem**: They were failing due to the configs not parsing with window's default encoding

**Solution**: Specify that the encoding is utf-8
