### PR TITLE
Light page tweaks new

### DIFF
--- a/home_assistant_streamdeck_yaml.py
+++ b/home_assistant_streamdeck_yaml.py
@@ -14,6 +14,7 @@ import math
 import re
 import time
 import warnings
+import locale 
 from contextlib import asynccontextmanager
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
@@ -2590,10 +2591,10 @@ def main() -> None:
     from dotenv import load_dotenv
 
     load_dotenv()
-
+    
     # Get the system default encoding
     system_encoding = locale.getpreferredencoding()
-    yaml_encoding = os.getenv("YAML_ENCODING", system_encoding)
+    yaml_encoding = os.getenv('YAML_ENCODING', system_encoding)
 
     parser = argparse.ArgumentParser(
         epilog=_help(),

--- a/home_assistant_streamdeck_yaml.py
+++ b/home_assistant_streamdeck_yaml.py
@@ -262,8 +262,6 @@ class Button(_ButtonDialBase, extra="forbid"):  # type: ignore[call-arg]
         " The dictionary can contain the following keys:"
         " The `colors` key and a value a list of max (`n_keys_on_streamdeck - 6`) hex colors."
         " The `color_temp_kelvin` key and a value a list of max (`n_keys_on_streamdeck - 6`) color temperatures in Kelvin."
-        " The `colors` key and a value a list of max (`n_keys_on_streamdeck - 6`) hex colors."
-        " The `color_temp_kelvin` key and a value a list of max (`n_keys_on_streamdeck - 6`) color temperatures in Kelvin."
         " The `colormap` key and a value a colormap (https://matplotlib.org/stable/tutorials/colors/colormaps.html)"
         " The `brightness` key and a value a brightness level (0-100)."
         " can be used. This requires the `matplotlib` package to be installed. If no"

--- a/home_assistant_streamdeck_yaml.py
+++ b/home_assistant_streamdeck_yaml.py
@@ -877,7 +877,9 @@ class Config(BaseModel):
     _include_files: list[Path] = PrivateAttr(default_factory=list)
 
     @classmethod
-    def load(cls: type[Config], fname: Path, yaml_encoding: str | None = None) -> Config:
+    def load(
+        cls: type[Config], fname: Path, yaml_encoding: str | None = None,
+    ) -> Config:
         """Read the configuration file."""
         with fname.open() as f:
             data, include_files = safe_load_yaml(

--- a/home_assistant_streamdeck_yaml.py
+++ b/home_assistant_streamdeck_yaml.py
@@ -260,11 +260,12 @@ class Button(_ButtonDialBase, extra="forbid"):  # type: ignore[call-arg]
         " If `go-to-page`, the data should be an `int` or `str` (name of the page)."
         " If `light-control`, the data should optionally be a dictionary."
         " The dictionary can contain the following keys:"
-        " The `colors` key and a value a list of max (`n_keys_on_streamdeck - 5`) hex colors."
-        " The `color_temp_kelvin` key and a value a list of max (`n_keys_on_streamdeck - 5`) color temperatures in Kelvin."
+        " The `colors` key and a value a list of max (`n_keys_on_streamdeck - 6`) hex colors."
+        " The `color_temp_kelvin` key and a value a list of max (`n_keys_on_streamdeck - 6`) color temperatures in Kelvin."
         " The `colormap` key and a value a colormap (https://matplotlib.org/stable/tutorials/colors/colormaps.html)"
         " can be used. This requires the `matplotlib` package to be installed. If no"
-        " list of `colors` or `colormap` is specified, 10 equally spaced colors are used.",
+        " list of `colors` or `colormap` is specified, 10 equally spaced colors are used."
+        " The `brightness` key and a value a brightness level (0-100)."
     )
 
     @classmethod
@@ -454,7 +455,7 @@ class Button(_ButtonDialBase, extra="forbid"):  # type: ignore[call-arg]
                 )
                 raise AssertionError(msg)
             # Can only have the following keys: colors and colormap
-            allowed_keys = {"colors", "colormap", "color_temp_kelvin"}
+            allowed_keys = {"colors", "colormap", "color_temp_kelvin", "brightness"}
             invalid_keys = v.keys() - allowed_keys
             if invalid_keys:
                 msg = (
@@ -479,6 +480,13 @@ class Button(_ButtonDialBase, extra="forbid"):  # type: ignore[call-arg]
                         raise AssertionError(msg)  # noqa: TRY004
                 # Cast color_temp_kelvin to tuple (to make it hashable)
                 v["color_temp_kelvin"] = tuple(v["color_temp_kelvin"])
+            if "brightness" in v:
+                for brightness in v["brightness"]:
+                    if not isinstance(brightness, int):
+                        msg = "All brightness must be integers"
+                        raise AssertionError(msg)  # noqa: TRY004
+                # Cast brightness to tuple (to make it hashable)
+                v["brightness"] = tuple(v["brightness"])
         return v
 
     def maybe_start_or_cancel_timer(
@@ -1268,6 +1276,7 @@ def _light_page(
     colors: tuple[str, ...] | None,
     color_temp_kelvin: tuple[int, ...] | None,
     colormap: str | None,
+    brightness: tuple[int, ...] | None,
 ) -> Page:
     """Return a page of buttons for controlling lights."""
     if colormap is None and colors is None:
@@ -1298,13 +1307,13 @@ def _light_page(
         for kelvin in (color_temp_kelvin or ())
     ]
     buttons_brightness = []
-    for brightness in [0, 10, 30, 60, 100]:
+    for brightness in brightness if brightness is not None else [0, 33, 66, 100]:
         background_color = _scale_hex_color("#FFFFFF", brightness / 100)
         button = Button(
             icon_background_color=background_color,
             service="light.turn_on",
             text_color=_max_contrast_color(background_color),
-            text=f"{brightness}%",
+            text=f"{brightness}%" if brightness > 0 else "OFF",
             service_data={
                 "entity_id": entity_id,
                 "brightness_pct": brightness,
@@ -2201,6 +2210,7 @@ async def _handle_key_press(
             colormap=button.special_type_data.get("colormap", None),
             colors=button.special_type_data.get("colors", None),
             color_temp_kelvin=button.special_type_data.get("color_temp_kelvin", None),
+            brightness=button.special_type_data.get("brightness", None),
         )
         config._detached_page = page
         update_all()

--- a/home_assistant_streamdeck_yaml.py
+++ b/home_assistant_streamdeck_yaml.py
@@ -867,11 +867,7 @@ class Config(BaseModel):
     ) -> Config:
         """Read the configuration file."""
         with fname.open() as f:
-            data, include_files = safe_load_yaml(
-                f,
-                return_included_paths=True,
-                encoding=yaml_encoding,
-            )
+            data, include_files = safe_load_yaml(f, return_included_paths=True, encoding=yaml_encoding)
             config = cls(**data)  # type: ignore[arg-type]
             config._configuration_file = fname
             config._include_files = include_files

--- a/home_assistant_streamdeck_yaml.py
+++ b/home_assistant_streamdeck_yaml.py
@@ -260,8 +260,8 @@ class Button(_ButtonDialBase, extra="forbid"):  # type: ignore[call-arg]
         " If `go-to-page`, the data should be an `int` or `str` (name of the page)."
         " If `light-control`, the data should optionally be a dictionary."
         " The dictionary can contain the following keys:"
-        " The `colors` key and a value a list of max (`n_keys_on_streamdeck - 6`) hex colors."
-        " The `color_temp_kelvin` key and a value a list of max (`n_keys_on_streamdeck - 6`) color temperatures in Kelvin."
+        " The `colors` key and a value a list of max (`n_keys_on_streamdeck - 5`) hex colors."
+        " The `color_temp_kelvin` key and a value a list of max (`n_keys_on_streamdeck - 5`) color temperatures in Kelvin."
         " The `colormap` key and a value a colormap (https://matplotlib.org/stable/tutorials/colors/colormaps.html)"
         " can be used. This requires the `matplotlib` package to be installed. If no"
         " list of `colors` or `colormap` is specified, 10 equally spaced colors are used.",

--- a/home_assistant_streamdeck_yaml.py
+++ b/home_assistant_streamdeck_yaml.py
@@ -265,6 +265,7 @@ class Button(_ButtonDialBase, extra="forbid"):  # type: ignore[call-arg]
         " The `color_temp_kelvin` key and a value a list of max (`n_keys_on_streamdeck - 6`) color temperatures in Kelvin."
         " The `colormap` key and a value a colormap (https://matplotlib.org/stable/tutorials/colors/colormaps.html)"
         " The `brightness` key and a value a brightness level (0-100)."
+        " The `brightness` key and a value a brightness level (0-100)."
         " can be used. This requires the `matplotlib` package to be installed. If no"
         " list of `colors` or `colormap` is specified, 10 equally spaced colors are used.",
     )

--- a/home_assistant_streamdeck_yaml.py
+++ b/home_assistant_streamdeck_yaml.py
@@ -10,7 +10,6 @@ import hashlib
 import io
 import json
 import locale
-import locale
 import math
 import re
 import time
@@ -883,9 +882,7 @@ class Config(BaseModel):
         """Read the configuration file."""
         with fname.open() as f:
             data, include_files = safe_load_yaml(
-                f,
-                return_included_paths=True,
-                encoding=yaml_encoding,
+                f, return_included_paths=True, encoding=yaml_encoding,
             )
             config = cls(**data)  # type: ignore[arg-type]
             config._configuration_file = fname

--- a/home_assistant_streamdeck_yaml.py
+++ b/home_assistant_streamdeck_yaml.py
@@ -1004,12 +1004,13 @@ class Config(BaseModel):
                 return p
         console.log(f"Could find page {page}, staying on current page")
         return self.current_page()
-    
+
     def close_page(self) -> Page:
         """Close the current page."""
         self._detached_page = None
         self._current_page_index = self._parent_page_index
         return self.current_page()
+
 
 def _next_id() -> int:
     global _ID_COUNTER
@@ -2192,7 +2193,7 @@ async def _handle_key_press(
         update_all()
     elif button.special_type == "close-page":
         config.close_page()
-        update_all()    
+        update_all()
     elif button.special_type == "go-to-page":
         assert isinstance(button.special_type_data, (str, int))
         config.to_page(button.special_type_data)  # type: ignore[arg-type]

--- a/home_assistant_streamdeck_yaml.py
+++ b/home_assistant_streamdeck_yaml.py
@@ -822,6 +822,7 @@ class Page(BaseModel):
 
 class Config(BaseModel):
     """Configuration file."""
+
     yaml_encoding: str = Field(
         default="utf-8",
         description="The encoding of the YAML file.",

--- a/home_assistant_streamdeck_yaml.py
+++ b/home_assistant_streamdeck_yaml.py
@@ -822,8 +822,7 @@ class Page(BaseModel):
 
 class Config(BaseModel):
     """Configuration file."""
-
-    yaml_encoding: str | None = Field(
+    yaml_encoding: str = Field(
         default="utf-8",
         description="The encoding of the YAML file.",
     )

--- a/home_assistant_streamdeck_yaml.py
+++ b/home_assistant_streamdeck_yaml.py
@@ -882,7 +882,9 @@ class Config(BaseModel):
         """Read the configuration file."""
         with fname.open() as f:
             data, include_files = safe_load_yaml(
-                f, return_included_paths=True, encoding=yaml_encoding,
+                f,
+                return_included_paths=True,
+                encoding=yaml_encoding,
             )
             config = cls(**data)  # type: ignore[arg-type]
             config._configuration_file = fname

--- a/home_assistant_streamdeck_yaml.py
+++ b/home_assistant_streamdeck_yaml.py
@@ -1005,13 +1005,12 @@ class Config(BaseModel):
                 return p
         console.log(f"Could find page {page}, staying on current page")
         return self.current_page()
-
+    
     def close_page(self) -> Page:
         """Close the current page."""
         self._detached_page = None
         self._current_page_index = self._parent_page_index
         return self.current_page()
-
 
 def _next_id() -> int:
     global _ID_COUNTER
@@ -2194,7 +2193,7 @@ async def _handle_key_press(
         update_all()
     elif button.special_type == "close-page":
         config.close_page()
-        update_all()
+        update_all()    
     elif button.special_type == "go-to-page":
         assert isinstance(button.special_type_data, (str, int))
         config.to_page(button.special_type_data)  # type: ignore[arg-type]

--- a/home_assistant_streamdeck_yaml.py
+++ b/home_assistant_streamdeck_yaml.py
@@ -1004,12 +1004,13 @@ class Config(BaseModel):
                 return p
         console.log(f"Could find page {page}, staying on current page")
         return self.current_page()
-    
+
     def close_page(self) -> Page:
         """Close the current page."""
         self._detached_page = None
         self._current_page_index = self._parent_page_index
         return self.current_page()
+
 
 def _next_id() -> int:
     global _ID_COUNTER
@@ -1312,7 +1313,7 @@ def _light_page(
             icon_background_color=background_color,
             service="light.turn_on",
             text_color=_max_contrast_color(background_color),
-            text=f"{brightness}%" if brightness >0 else "OFF",
+            text=f"{brightness}%" if brightness > 0 else "OFF",
             service_data={
                 "entity_id": entity_id,
                 "brightness_pct": brightness,
@@ -1322,7 +1323,10 @@ def _light_page(
     buttons_back = [Button(special_type="close-page")]
     return Page(
         name="Lights",
-        buttons=buttons_colors + buttons_color_temp_kelvin + buttons_brightness + buttons_back,
+        buttons=buttons_colors
+        + buttons_color_temp_kelvin
+        + buttons_brightness
+        + buttons_back,
     )
 
 
@@ -2189,7 +2193,7 @@ async def _handle_key_press(
         update_all()
     elif button.special_type == "close-page":
         config.close_page()
-        update_all()    
+        update_all()
     elif button.special_type == "go-to-page":
         assert isinstance(button.special_type_data, (str, int))
         config.to_page(button.special_type_data)  # type: ignore[arg-type]

--- a/home_assistant_streamdeck_yaml.py
+++ b/home_assistant_streamdeck_yaml.py
@@ -232,6 +232,7 @@ class Button(_ButtonDialBase, extra="forbid"):  # type: ignore[call-arg]
             "previous-page",
             "empty",
             "go-to-page",
+            "close-page",
             "turn-off",
             "light-control",
             "reload",
@@ -246,6 +247,7 @@ class Button(_ButtonDialBase, extra="forbid"):  # type: ignore[call-arg]
         " If `previous-page`, the button will go to the previous page."
         " If `turn-off`, the button will turn off the SteamDeck until any button is pressed."
         " If `empty`, the button will be empty."
+        " If `close-page`, the button will close the current page and return to the previous one."
         " If `go-to-page`, the button will go to the page specified by `special_type_data`"
         " (either an `int` or `str` (name of the page))."
         " If `light-control`, the button will control a light, and the `special_type_data`"
@@ -373,6 +375,9 @@ class Button(_ButtonDialBase, extra="forbid"):  # type: ignore[call-arg]
             page = button.special_type_data
             text = button.text or f"Go to\nPage\n{page}"
             icon_mdi = button.icon_mdi or "book-open-page-variant"
+        elif button.special_type == "close-page":
+            text = button.text or "Close\nPage"
+            icon_mdi = button.icon_mdi or "arrow-u-left-bottom-bold"
         elif button.special_type == "turn-off":
             text = button.text or "Turn off"
             icon_mdi = button.icon_mdi or "power"
@@ -779,6 +784,8 @@ class Page(BaseModel):
         description="A list of dials on the page.",
     )
 
+    _parent_page_index: int = PrivateAttr([])
+
     _dials_sorted: list[Dial] = PrivateAttr([])
 
     def sort_dials(self) -> list[tuple[Dial, Dial | None]]:
@@ -854,6 +861,7 @@ class Config(BaseModel):
         " be reloaded when it is modified.",
     )
     _current_page_index: int = PrivateAttr(default=0)
+    _parent_page_index: int = PrivateAttr(default=0)
     _is_on: bool = PrivateAttr(default=True)
     _detached_page: Page | None = PrivateAttr(default=None)
     _configuration_file: Path | None = PrivateAttr(default=None)
@@ -922,6 +930,7 @@ class Config(BaseModel):
 
     def next_page(self) -> Page:
         """Go to the next page."""
+        self._parent_page_index = self._current_page_index
         self._current_page_index = self.next_page_index
         return self.pages[self._current_page_index]
 
@@ -937,6 +946,7 @@ class Config(BaseModel):
 
     def previous_page(self) -> Page:
         """Go to the previous page."""
+        self._parent_page_index = self._current_page_index
         self._current_page_index = self.previous_page_index
         return self.pages[self._current_page_index]
 
@@ -970,6 +980,7 @@ class Config(BaseModel):
     def to_page(self, page: int | str) -> Page:
         """Go to a page based on the page name or index."""
         if isinstance(page, int):
+            self._parent_page_index = self._current_page_index
             self._current_page_index = page
             return self.current_page()
 
@@ -984,7 +995,12 @@ class Config(BaseModel):
                 return p
         console.log(f"Could find page {page}, staying on current page")
         return self.current_page()
-
+    
+    def close_page(self) -> Page:
+        """Close the current page."""
+        self._detached_page = None
+        self._current_page_index = self._parent_page_index
+        return self.current_page()
 
 def _next_id() -> int:
     global _ID_COUNTER
@@ -2160,6 +2176,9 @@ async def _handle_key_press(
     elif button.special_type == "previous-page":
         config.previous_page()
         update_all()
+    elif button.special_type == "close-page":
+        config.close_page()
+        update_all()    
     elif button.special_type == "go-to-page":
         assert isinstance(button.special_type_data, (str, int))
         config.to_page(button.special_type_data)  # type: ignore[arg-type]

--- a/home_assistant_streamdeck_yaml.py
+++ b/home_assistant_streamdeck_yaml.py
@@ -1273,7 +1273,7 @@ def _light_page(
     n_colors: int,
     colors: tuple[str, ...] | None,
     color_temp_kelvin: tuple[int, ...] | None,
-    brightness: tuple[int, ...],
+    brightness: tuple[int, ...] | None,
     colormap: str | None,
 ) -> Page:
     """Return a page of buttons for controlling lights."""

--- a/home_assistant_streamdeck_yaml.py
+++ b/home_assistant_streamdeck_yaml.py
@@ -823,7 +823,7 @@ class Page(BaseModel):
 class Config(BaseModel):
     """Configuration file."""
 
-    yaml_encoding: str = Field(
+    yaml_encoding: str | None = Field(
         default="utf-8",
         description="The encoding of the YAML file.",
     )
@@ -860,11 +860,7 @@ class Config(BaseModel):
     _include_files: list[Path] = PrivateAttr(default_factory=list)
 
     @classmethod
-    def load(
-        cls: type[Config],
-        fname: Path,
-        yaml_encoding: str | None = None,
-    ) -> Config:
+    def load(cls: type[Config], fname: Path, yaml_encoding: str | None = None) -> Config:
         """Read the configuration file."""
         with fname.open() as f:
             data, include_files = safe_load_yaml(

--- a/home_assistant_streamdeck_yaml.py
+++ b/home_assistant_streamdeck_yaml.py
@@ -261,9 +261,10 @@ class Button(_ButtonDialBase, extra="forbid"):  # type: ignore[call-arg]
         " If `go-to-page`, the data should be an `int` or `str` (name of the page)."
         " If `light-control`, the data should optionally be a dictionary."
         " The dictionary can contain the following keys:"
-        " The `colors` key and a value a list of max (`n_keys_on_streamdeck - 5`) hex colors."
-        " The `color_temp_kelvin` key and a value a list of max (`n_keys_on_streamdeck - 5`) color temperatures in Kelvin."
+        " The `colors` key and a value a list of max (`n_keys_on_streamdeck - 6`) hex colors."
+        " The `color_temp_kelvin` key and a value a list of max (`n_keys_on_streamdeck - 6`) color temperatures in Kelvin."
         " The `colormap` key and a value a colormap (https://matplotlib.org/stable/tutorials/colors/colormaps.html)"
+        " The `brightness` key and a value a brightness level (0-100)."
         " can be used. This requires the `matplotlib` package to be installed. If no"
         " list of `colors` or `colormap` is specified, 10 equally spaced colors are used.",
     )
@@ -455,7 +456,7 @@ class Button(_ButtonDialBase, extra="forbid"):  # type: ignore[call-arg]
                 )
                 raise AssertionError(msg)
             # Can only have the following keys: colors and colormap
-            allowed_keys = {"colors", "colormap", "color_temp_kelvin"}
+            allowed_keys = {"colors", "colormap", "color_temp_kelvin", "brightness"}
             invalid_keys = v.keys() - allowed_keys
             if invalid_keys:
                 msg = (
@@ -480,6 +481,13 @@ class Button(_ButtonDialBase, extra="forbid"):  # type: ignore[call-arg]
                         raise AssertionError(msg)  # noqa: TRY004
                 # Cast color_temp_kelvin to tuple (to make it hashable)
                 v["color_temp_kelvin"] = tuple(v["color_temp_kelvin"])
+            if "brightness" in v:
+                for brightness in v["brightness"]:
+                    if not isinstance(brightness, int):
+                        msg = "All brightness must be integers"
+                        raise AssertionError(msg)  # noqa: TRY004
+                # Cast brightness to tuple (to make it hashable)
+                v["brightness"] = tuple(v["brightness"])
         return v
 
     def maybe_start_or_cancel_timer(
@@ -1265,6 +1273,7 @@ def _light_page(
     n_colors: int,
     colors: tuple[str, ...] | None,
     color_temp_kelvin: tuple[int, ...] | None,
+    brightness: tuple[int, ...],
     colormap: str | None,
 ) -> Page:
     """Return a page of buttons for controlling lights."""
@@ -1296,22 +1305,23 @@ def _light_page(
         for kelvin in (color_temp_kelvin or ())
     ]
     buttons_brightness = []
-    for brightness in [0, 10, 30, 60, 100]:
+    for brightness in brightness if brightness is not None else [0, 33, 66, 100]:
         background_color = _scale_hex_color("#FFFFFF", brightness / 100)
         button = Button(
             icon_background_color=background_color,
             service="light.turn_on",
             text_color=_max_contrast_color(background_color),
-            text=f"{brightness}%",
+            text=f"{brightness}%" if brightness >0 else "OFF",
             service_data={
                 "entity_id": entity_id,
                 "brightness_pct": brightness,
             },
         )
         buttons_brightness.append(button)
+    buttons_back = [Button(special_type="close-page")]
     return Page(
         name="Lights",
-        buttons=buttons_colors + buttons_color_temp_kelvin + buttons_brightness,
+        buttons=buttons_colors + buttons_color_temp_kelvin + buttons_brightness + buttons_back,
     )
 
 
@@ -2191,10 +2201,11 @@ async def _handle_key_press(
         assert isinstance(button.special_type_data, dict)
         page = _light_page(
             entity_id=button.entity_id,
-            n_colors=10,
+            n_colors=9,
             colormap=button.special_type_data.get("colormap", None),
             colors=button.special_type_data.get("colors", None),
             color_temp_kelvin=button.special_type_data.get("color_temp_kelvin", None),
+            brightness=button.special_type_data.get("brightness", None),
         )
         config._detached_page = page
         update_all()

--- a/home_assistant_streamdeck_yaml.py
+++ b/home_assistant_streamdeck_yaml.py
@@ -262,8 +262,9 @@ class Button(_ButtonDialBase, extra="forbid"):  # type: ignore[call-arg]
         " The dictionary can contain the following keys:"
         " The `colors` key and a value a list of max (`n_keys_on_streamdeck - 6`) hex colors."
         " The `color_temp_kelvin` key and a value a list of max (`n_keys_on_streamdeck - 6`) color temperatures in Kelvin."
+        " The `colors` key and a value a list of max (`n_keys_on_streamdeck - 6`) hex colors."
+        " The `color_temp_kelvin` key and a value a list of max (`n_keys_on_streamdeck - 6`) color temperatures in Kelvin."
         " The `colormap` key and a value a colormap (https://matplotlib.org/stable/tutorials/colors/colormaps.html)"
-        " The `brightness` key and a value a brightness level (0-100)."
         " The `brightness` key and a value a brightness level (0-100)."
         " can be used. This requires the `matplotlib` package to be installed. If no"
         " list of `colors` or `colormap` is specified, 10 equally spaced colors are used.",

--- a/home_assistant_streamdeck_yaml.py
+++ b/home_assistant_streamdeck_yaml.py
@@ -10,11 +10,11 @@ import hashlib
 import io
 import json
 import locale
+import locale
 import math
 import re
 import time
 import warnings
-import locale 
 from contextlib import asynccontextmanager
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
@@ -867,7 +867,9 @@ class Config(BaseModel):
     ) -> Config:
         """Read the configuration file."""
         with fname.open() as f:
-            data, include_files = safe_load_yaml(f, return_included_paths=True, encoding=yaml_encoding)
+            data, include_files = safe_load_yaml(
+                f, return_included_paths=True, encoding=yaml_encoding,
+            )
             config = cls(**data)  # type: ignore[arg-type]
             config._configuration_file = fname
             config._include_files = include_files
@@ -2552,8 +2554,7 @@ def safe_load_yaml(
             variables = mapping["vars"]
 
             loaded_data = yaml.load(
-                filepath.read_text(encoding=encoding),
-                IncludeLoader,  # noqa: S506
+                filepath.read_text(encoding=encoding), IncludeLoader,
             )
             assert loaded_data is not None
             assert variables is not None
@@ -2587,10 +2588,10 @@ def main() -> None:
     from dotenv import load_dotenv
 
     load_dotenv()
-    
+
     # Get the system default encoding
     system_encoding = locale.getpreferredencoding()
-    yaml_encoding = os.getenv('YAML_ENCODING', system_encoding)
+    yaml_encoding = os.getenv("YAML_ENCODING", system_encoding)
 
     parser = argparse.ArgumentParser(
         epilog=_help(),

--- a/home_assistant_streamdeck_yaml.py
+++ b/home_assistant_streamdeck_yaml.py
@@ -867,7 +867,9 @@ class Config(BaseModel):
         """Read the configuration file."""
         with fname.open() as f:
             data, include_files = safe_load_yaml(
-                f, return_included_paths=True, encoding=yaml_encoding,
+                f,
+                return_included_paths=True,
+                encoding=yaml_encoding,
             )
             config = cls(**data)  # type: ignore[arg-type]
             config._configuration_file = fname
@@ -2553,7 +2555,8 @@ def safe_load_yaml(
             variables = mapping["vars"]
 
             loaded_data = yaml.load(
-                filepath.read_text(encoding=encoding), IncludeLoader,
+                filepath.read_text(encoding=encoding),
+                IncludeLoader,
             )
             assert loaded_data is not None
             assert variables is not None

--- a/includes/home.yaml
+++ b/includes/home.yaml
@@ -19,8 +19,8 @@
       - 6535  # from default HA options
     brightness:
       - 0
-      - 10
-      - 50
+      - 10 
+      - 50 
       - 100
 - special_type: go-to-page
   special_type_data: all-lights

--- a/includes/home.yaml
+++ b/includes/home.yaml
@@ -17,6 +17,11 @@
       - 3521  # from default HA options
       - 5025  # from default HA options
       - 6535  # from default HA options
+    brightness:
+      - 0
+      - 10 
+      - 50 
+      - 100
 - special_type: go-to-page
   special_type_data: all-lights
   text: |

--- a/includes/home.yaml
+++ b/includes/home.yaml
@@ -19,8 +19,8 @@
       - 6535  # from default HA options
     brightness:
       - 0
-      - 10 
-      - 50 
+      - 10
+      - 50
       - 100
 - special_type: go-to-page
   special_type_data: all-lights

--- a/includes/home.yaml
+++ b/includes/home.yaml
@@ -17,11 +17,6 @@
       - 3521  # from default HA options
       - 5025  # from default HA options
       - 6535  # from default HA options
-    brightness:
-      - 0
-      - 10
-      - 50
-      - 100
 - special_type: go-to-page
   special_type_data: all-lights
   text: |

--- a/includes/home.yaml
+++ b/includes/home.yaml
@@ -17,6 +17,11 @@
       - 3521  # from default HA options
       - 5025  # from default HA options
       - 6535  # from default HA options
+    brightness:
+      - 0
+      - 10
+      - 50
+      - 100
 - special_type: go-to-page
   special_type_data: all-lights
   text: |

--- a/includes/testing.yaml
+++ b/includes/testing.yaml
@@ -56,6 +56,6 @@
   special_type_data: bas
 - special_type: empty
 - special_type: empty
-- special_type: empty
+- special_type: close-page
 - special_type: previous-page
 - special_type: next-page

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -227,6 +227,7 @@ def test_example_close_pages(config: Config) -> None:
     assert config._current_page_index == 1
     config.close_page()
     assert config._current_page_index == 0
+    
 
 
 def test_example_close_pages(config: Config) -> None:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -97,6 +97,7 @@ def button_dict() -> dict[str, dict[str, Any]]:
                     "#FFD700",  # gold
                     "#008000",  # dark green
                 ],
+                "brightness": [0, 10, 50, 100],
             },
         },
         "icon_from_url": {
@@ -217,6 +218,16 @@ def test_example_config_browsing_pages(config: Config) -> None:
     first_page = config.to_page(first_page.name)
     assert config._current_page_index == 0
     assert config.button(0) == first_page.buttons[0]
+
+def test_example_close_pages(config: Config) -> None:
+    """Test example config close pages."""
+    assert isinstance(config, Config)
+    assert config._current_page_index == 0
+    second_page = config.next_page()
+    assert isinstance(second_page, Page)
+    assert config._current_page_index == 1
+    config.close_pages()
+    assert config._current_page_index == 0
 
 
 def test_example_close_pages(config: Config) -> None:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -218,6 +218,7 @@ def test_example_config_browsing_pages(config: Config) -> None:
     assert config._current_page_index == 0
     assert config.button(0) == first_page.buttons[0]
 
+
 def test_example_close_pages(config: Config) -> None:
     """Test example config close pages."""
     assert isinstance(config, Config)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -97,7 +97,6 @@ def button_dict() -> dict[str, dict[str, Any]]:
                     "#FFD700",  # gold
                     "#008000",  # dark green
                 ],
-                "brightness": [0, 10, 50, 100],
             },
         },
         "icon_from_url": {

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -437,6 +437,7 @@ def test_light_page() -> None:
         colormap="hsv",
         colors=None,
         color_temp_kelvin=None,
+        brightness=None,
     )
     buttons = page.buttons
     assert len(buttons) == BUTTONS_PER_PAGE

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -225,7 +225,7 @@ def test_example_close_pages(config: Config) -> None:
     second_page = config.next_page()
     assert isinstance(second_page, Page)
     assert config._current_page_index == 1
-    config.close_pages()
+    config.close_page()
     assert config._current_page_index == 0
 
 
@@ -435,6 +435,7 @@ def test_light_page() -> None:
         colormap="hsv",
         colors=None,
         color_temp_kelvin=None,
+        brightness=None,
     )
     buttons = page.buttons
     assert len(buttons) == BUTTONS_PER_PAGE

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -227,6 +227,7 @@ def test_example_close_pages(config: Config) -> None:
     assert config._current_page_index == 1
     config.close_page()
     assert config._current_page_index == 0
+    
 
 
 @pytest.mark.skipif(
@@ -1102,7 +1103,7 @@ async def test_anonymous_page(
     )
     anon = Page(
         name="anon",
-        buttons=[Button(text="yolo"), Button(text="foo", delay=0.1)],
+        buttons=[Button(text="yolo"), Button(text="foo", delay=0.1), Button(special_type="close-page")],
     )
     config = Config(pages=[home], anonymous_pages=[anon])
     assert config._current_page_index == 0
@@ -1136,3 +1137,9 @@ async def test_anonymous_page(
     # Should now be the button on the first page
     button = config.button(0)
     assert button.special_type == "go-to-page"
+    # Back to anon page to test that the close button works properly
+    assert config.to_page("anon") == anon
+    await press(mock_deck, 2, key_pressed=True)
+    assert config._detached_page is None
+    assert config.current_page() == home
+

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -437,7 +437,6 @@ def test_light_page() -> None:
         colormap="hsv",
         colors=None,
         color_temp_kelvin=None,
-        brightness=None,
     )
     buttons = page.buttons
     assert len(buttons) == BUTTONS_PER_PAGE

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -225,7 +225,7 @@ def test_example_close_pages(config: Config) -> None:
     second_page = config.next_page()
     assert isinstance(second_page, Page)
     assert config._current_page_index == 1
-    config.close_pages()
+    config.close_page()
     assert config._current_page_index == 0
 
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -97,6 +97,7 @@ def button_dict() -> dict[str, dict[str, Any]]:
                     "#FFD700",  # gold
                     "#008000",  # dark green
                 ],
+                "brightness": [0, 10, 50, 100],
             },
         },
         "icon_from_url": {
@@ -217,6 +218,16 @@ def test_example_config_browsing_pages(config: Config) -> None:
     first_page = config.to_page(first_page.name)
     assert config._current_page_index == 0
     assert config.button(0) == first_page.buttons[0]
+
+def test_example_close_pages(config: Config) -> None:
+    """Test example config close pages."""
+    assert isinstance(config, Config)
+    assert config._current_page_index == 0
+    second_page = config.next_page()
+    assert isinstance(second_page, Page)
+    assert config._current_page_index == 1
+    config.close_pages()
+    assert config._current_page_index == 0
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
(Review this after add-close-page-button, as this branch is based on it)

Tweak the light control page:
- Add "Back" button (lower right corner), in case one wants to close the page without doing any action
- 0% Brightness now shows as OFF
- One can specify the brightness values in config
- Only 4 brightness values are now include by default (so that the bottom line is Brightness + Close page)