### PR TITLE
Allow optional weaker encryption for ssl handshake

### DIFF
--- a/home_assistant_streamdeck_yaml.py
+++ b/home_assistant_streamdeck_yaml.py
@@ -2611,19 +2611,6 @@ def main() -> None:
     system_encoding = locale.getpreferredencoding()
     yaml_encoding = os.getenv("YAML_ENCODING", system_encoding)
 
-    def str_to_bool(val: str | None) -> bool:
-        """Convert a string to a boolean, raising ValueError for invalid values."""
-        if val is None:
-            return False
-        val_lower = val.lower()
-        if val_lower in ("true", "1", "t", "y", "yes"):
-            return True
-        if val_lower in ("false", "0", "f", "n", "no"):
-            return False
-        msg = f"Invalid boolean string: {val}"
-        console.log(f"[b red]{msg}[/]")
-        raise ValueError(msg)
-
     parser = argparse.ArgumentParser(
         epilog=_help(),
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -2647,11 +2634,12 @@ def main() -> None:
     )
     parser.add_argument(
         "--allow-weaker-ssl",
-        type=str_to_bool,
-        default=str_to_bool(os.getenv("ALLOW_WEAKER_SSL")),
-        help="Allow weaker SSL connections. True makes the connection less safe, but might be needed for underpowered devices.",
+        action="store_true",
+        help="Allow less secure SSL (security level 1) for compatibility with slower hardware (e.g., RPi Zero).",
     )
     args = parser.parse_args()
+    if os.getenv("ALLOW_WEAKER_SSL", "").lower().startswith(("y", "t", "1")):
+        args.allow_weaker_ssl = True
     console.log(f"Using version {__version__} of the Home Assistant Stream Deck.")
     console.log(
         f"Starting Stream Deck integration with {args.host=}, {args.config=}, {args.protocol=}, {args.allow_weaker_ssl=}",

--- a/home_assistant_streamdeck_yaml.py
+++ b/home_assistant_streamdeck_yaml.py
@@ -1327,8 +1327,6 @@ async def setup_ws(
     """Set up the connection to Home Assistant."""
     uri = f"{protocol}://{host}/api/websocket"
     ssl_context = ssl.create_default_context()
-    if allow_weaker_ssl:
-        ssl_context.set_ciphers("DEFAULT@SECLEVEL=1")
     while True:
         try:
             # limit size to 10 MiB
@@ -1346,6 +1344,9 @@ async def setup_ws(
             # Connection was reset, retrying in 3 seconds
             console.print_exception(show_locals=True)
             console.log("Connection was reset, retrying in 3 seconds")
+            if allow_weaker_ssl:
+                ssl_context.set_ciphers("DEFAULT@SECLEVEL=1")
+                console.log("Using weaker SSL settings")
             await asyncio.sleep(5)
 
 


### PR DESCRIPTION
I was having trouble getting an SSL handshake with my pi zero 2W. 

It seems like the handshake operation might be too expensive for it.
Allowing a lower ssl spec seems to help.

This adds a command line flag / .env allow_weaker_ssl (bool), and uses weaker ssl accordingly.