### PR TITLE
add is_number filter to jinja2 parser

### DIFF
--- a/home_assistant_streamdeck_yaml.py
+++ b/home_assistant_streamdeck_yaml.py
@@ -1578,6 +1578,22 @@ def _max_filter(value: float, other_value: float) -> float:
     return max(value, other_value)
 
 
+def _is_number_filter(value: Any | None) -> bool:
+    """Check if a value is a number (int, float, or string representation of a number)."""
+    if value is None:
+        return False
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return True
+    if isinstance(value, str):
+        try:
+            float(value)
+        except ValueError:
+            return False
+        else:
+            return True
+    return False
+
+
 def _round(num: float, digits: int) -> int | float:
     """Returns rounded value with number of digits."""
     return round(num, digits)
@@ -1627,6 +1643,7 @@ def _render_jinja(
         )
         env.filters["min"] = _min_filter
         env.filters["max"] = _max_filter
+        env.filters["is_number"] = _is_number_filter
         template = env.from_string(text)
         return template.render(
             min=min,

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -944,6 +944,30 @@ async def test_button_with_target(
             {"switch.wifi_switch": {"state": "off"}},
             "wifi-off",
         ),
+        # Test is_number filter
+        (
+            """
+            {% if state_attr('sensor.temp1', 'temperature') | is_number %}
+            {{ state_attr('sensor.temp1', 'temperature') }}°C
+            {% else %}
+            {{ state_attr('sensor.temp1', 'temperature') }}
+            {% endif %}
+            """,
+            {"sensor.temp1": {"attributes": {"temperature": "unavailable"}}},
+            "unavailable",
+        ),
+        # Test is_number filter
+        (
+            """
+            {% if state_attr('sensor.temp1', 'temperature') | is_number %}
+            {{ state_attr('sensor.temp1', 'temperature') }}°C
+            {% else %}
+            {{ state_attr('sensor.temp1', 'temperature') }}
+            {% endif %}
+            """,
+            {"sensor.temp1": {"attributes": {"temperature": 3.2}}},
+            "3.2°C",
+        ),
     ],
 )
 def test_render_jinja2_from_examples_readme(


### PR DESCRIPTION
adds the ability to run | is_number in templates.

e.g. use case:

          {% if (states('sensor.cold_plunge') | is_number) %}
            {{states('sensor.cold_plunge')}}°C
          {% else %}
            UNK
          {% endif %}