### PR TITLE
Fix bug on to_page when a detached page is active

### DIFF
--- a/home_assistant_streamdeck_yaml.py
+++ b/home_assistant_streamdeck_yaml.py
@@ -968,11 +968,11 @@ class Config(BaseModel):
 
     def to_page(self, page: int | str) -> Page:
         """Go to a page based on the page name or index."""
+        self.close_detached_page()
         if isinstance(page, int):
             self._parent_page_index = self._current_page_index
             self._current_page_index = page
             return self.current_page()
-
         for i, p in enumerate(self.pages):
             if p.name == page:
                 self._current_page_index = i

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1154,6 +1154,13 @@ async def test_anonymous_page(
     assert config._detached_page is None
     assert config.current_page() == home
 
+    # Test that to_page closes a detached page
+    config.load_page_as_detached(anon)
+    assert config.current_page() == anon
+    config.to_page(home.name)
+    assert config.current_page() == home
+    assert config._detached_page is None
+
 
 def test_page_switch_clears_unused_keys(state: dict[str, dict[str, Any]]) -> None:
     """Test that switching pages clears unused keys."""


### PR DESCRIPTION
Small bug fix, as currently calling to_page (non detached page) with a detached page active will have current_page return the detached page.
This doesn't happen in practice when pressing keys on the deck, (I found it by chance writing a test for another feature), but this way we have to_page work as expected, even when not called from a key press.

Here is a test that failed, and now works.
    config.load_page_as_detached(anon)
    assert config.current_page() == anon
    config.to_page(home.name)
    assert config.current_page() == home <failed here as showed current_page = anon>
    assert config._detached_page is None