### PR TITLE
Fix yaml loading bug on include

### DIFF
--- a/tests/test_yaml.py
+++ b/tests/test_yaml.py
@@ -160,7 +160,6 @@ def test_variable_substitution_in_include(tmp_path: Path) -> None:
     # Assert that data is a dictionary to satisfy MyPy
     data = cast("dict[str, Any]", data)
 
-    # Check that entity_id is substituted correctly (this will fail due to the bug)
     assert data["pages"][0]["dials"][0]["entity_id"] == "light.living_room", (
         "Failed to substitute ${eid} with light.living_room in entity_id"
     )

--- a/tests/test_yaml.py
+++ b/tests/test_yaml.py
@@ -2,6 +2,7 @@
 
 from io import StringIO
 from pathlib import Path
+from typing import Any, cast
 
 import pytest
 import yaml
@@ -109,3 +110,62 @@ def test_include_file_paths(tmp_path: Path) -> None:
         "main_key2": {"included_key2": "included_value2"},
     }
     assert set(included_files) == {included_file1, included_file2}
+
+
+def test_variable_substitution_in_include(tmp_path: Path) -> None:
+    """Test variable substitution in included YAML files."""
+    config_content = """
+    brightness: 100
+    state_entity_id: binary_sensor.anyone_home
+    auto_reload: true
+    return_to_home_after_no_presses:
+      duration: 10
+      home_page: Home
+    pages:
+      - !include {file: includes/light_page_plus.yaml, vars: {eid: light.living_room}}
+    """
+    light_page_plus_content = """
+    name: ${eid}
+    dials:
+      - entity_id: ${eid}
+        service: light.turn_on
+        service_data:
+          color_temp_kelvin: '{{ dial_value() | int}}'
+        icon: >
+          light-temperature-bar:
+        text: Color Temp
+        state_attribute: color_temp_kelvin
+        allow_touchscreen_events: true
+        delay: 0.5
+        dial_event_type: TURN
+        attributes:
+          step: 500
+          min: 2202
+          max: 6535
+    """
+
+    # Create directory structure
+    includes_dir = tmp_path / "includes"
+    includes_dir.mkdir()
+    config_file = tmp_path / "config.yaml"
+    light_page_plus_file = includes_dir / "light_page_plus.yaml"
+
+    config_file.write_text(config_content)
+    light_page_plus_file.write_text(light_page_plus_content)
+
+    # Load config with safe_load_yaml
+    with config_file.open() as f:
+        data = safe_load_yaml(f)
+
+    # Assert that data is a dictionary to satisfy MyPy
+    data = cast("dict[str, Any]", data)
+
+    # Check that entity_id is substituted correctly (this will fail due to the bug)
+    assert data["pages"][0]["dials"][0]["entity_id"] == "light.living_room", (
+        "Failed to substitute ${eid} with light.living_room in entity_id"
+    )
+
+    # Additional check: name field should be substituted correctly
+    assert data["pages"][0]["name"] == "light.living_room", (
+        "Failed to substitute ${eid} with light.living_room in name"
+    )


### PR DESCRIPTION
markdown

Copy
# Fix Variable Substitution in `safe_load_yaml` for Nested Lists

## Description
This PR fixes a bug in the `safe_load_yaml` function where variable substitutions (e.g., `${eid}`) were not applied to strings within nested lists, such as the `dials` list in included YAML files.

## Bug
The `safe_load_yaml` function failed to substitute variables in nested structures, particularly in lists of dictionaries. For example, given the following YAML configuration:

### `config.yaml`
```yaml
brightness: 100
state_entity_id: binary_sensor.anyone_home
auto_reload: true
return_to_home_after_no_presses:
  duration: 10
  home_page: Home
pages:
  - !include {file: includes/light_page_plus.yaml, vars: {eid: light.living_room}}
includes/light_page_plus.yaml
yaml

Copy
name: ${eid}
dials:
  - entity_id: ${eid}
    service: light.turn_on
    service_data:
      color_temp_kelvin: '{{ dial_value() | int}}'
    icon: >
      light-temperature-bar:
    text: Color Temp
    state_attribute: color_temp_kelvin
    allow_touchscreen_events: true
    delay: 0.5
    dial_event_type: TURN
    attributes:
      step: 500
      min: 2202
      max: 6535
The entity_id: ${eid} field in the dials list was not substituted, resulting in the following incorrect output in the log:

log

Copy
config: yaml_encoding='utf-8' pages=[Page(name='light.living_room', buttons=[],
dials=[Dial(entity_id='${eid}', linked_entity=None, service='light.turn_on',  # Bad value: '${eid}' instead of 'light.living_room'
service_data={'color_temp_kelvin': '{{ dial_value() | int}}'}, target=None, text='Color Temp',
...
The expected value for entity_id was light.living_room, but it remained ${eid} due to the bug.

Fix
The bug is fixed by modifying _traverse_yaml to return the modified node and handle strings in nested lists and dictionaries recursively.