### PR TITLE
Allow multiple includes

### DIFF
--- a/home_assistant_streamdeck_yaml.py
+++ b/home_assistant_streamdeck_yaml.py
@@ -2598,34 +2598,34 @@ def safe_load_yaml(
             self._root = Path(stream.name).parent if hasattr(stream, "name") else Path.cwd()
             super().__init__(stream)
 
-        def _include(self, node: yaml.nodes.Node) -> Any:
-            """Include file referenced at node."""
-            if isinstance(node.value, str):
-                filepath = self._root / str(self.construct_scalar(node))  # type: ignore[arg-type]
-                included_files.append(filepath)
-                with filepath.open(encoding=encoding) as included_file:
-                    return yaml.load(
-                        included_file,
-                        lambda stream: IncludeLoader(stream),  # type: ignore[arg-type] # noqa: S506
-                    )
-            else:
-                mapping = self.construct_mapping(node, deep=True)  # type: ignore[arg-type]
-                assert mapping is not None
-                filepath = self._root / str(mapping["file"])
-                included_files.append(filepath)
-                variables = mapping["vars"]
+    def _include(loader: IncludeLoader, node: yaml.nodes.Node) -> Any:
+        """Include file referenced at node."""
+        if isinstance(node.value, str):
+            filepath = loader._root / str(loader.construct_scalar(node))  # type: ignore[arg-type]
+            included_files.append(filepath)
+            with filepath.open(encoding=encoding) as included_file:
+                return yaml.load(
+                    included_file,
+                    lambda stream: IncludeLoader(stream),  # type: ignore[arg-type] # noqa: S506
+                )
+        else:
+            mapping = loader.construct_mapping(node, deep=True)  # type: ignore[arg-type]
+            assert mapping is not None
+            filepath = loader._root / str(mapping["file"])
+            included_files.append(filepath)
+            variables = mapping["vars"]
 
-                with filepath.open(encoding=encoding) as included_file:
-                    loaded_data = yaml.load(
-                        included_file,
-                        lambda stream: IncludeLoader(stream),  # type: ignore[arg-type] # noqa: S506 # type: ignore[arg-type]
-                    )
-                    assert loaded_data is not None
-                    assert variables is not None
-                    _traverse_yaml(loaded_data, variables)
-                    return loaded_data
+            with filepath.open(encoding=encoding) as included_file:
+                loaded_data = yaml.load(
+                    included_file,
+                    lambda stream: IncludeLoader(stream),  # type: ignore[arg-type] # noqa: S506
+                )
+                assert loaded_data is not None
+                assert variables is not None
+                _traverse_yaml(loaded_data, variables)
+                return loaded_data
 
-    IncludeLoader.add_constructor("!include", IncludeLoader._include)
+    IncludeLoader.add_constructor("!include", _include)
     loaded_data = yaml.load(f, IncludeLoader)  # noqa: S506
     if return_included_paths:
         return loaded_data, included_files

--- a/home_assistant_streamdeck_yaml.py
+++ b/home_assistant_streamdeck_yaml.py
@@ -40,12 +40,14 @@ from rich.table import Table
 from StreamDeck.DeviceManager import DeviceManager
 from StreamDeck.Devices.StreamDeck import DialEventType, TouchscreenEventType
 from StreamDeck.ImageHelpers import PILHelper
+from yaml.nodes import Node as YamlNode
 
 if TYPE_CHECKING:
     from collections.abc import Coroutine
 
     import pandas as pd
     from StreamDeck.Devices import StreamDeck
+    from yaml.nodes import Node as YamlNode
 
 
 try:
@@ -2574,21 +2576,27 @@ def safe_load_yaml(
     """Load a YAML file."""
     included_files = []
 
-    def _traverse_yaml(node: dict[str, Any], variables: dict[str, str]) -> None:
+    def _traverse_yaml(node: YamlNode, variables: dict[str, str]) -> Any:
         if isinstance(node, dict):
             for key, value in node.items():
-                if not isinstance(value, dict):
+                if isinstance(value, str):
+                    result = value
                     for var, var_value in variables.items():
-                        if not isinstance(value, str):
-                            continue
-
                         regex_format = rf"\$\{{{var}\}}"
-                        node[key] = re.sub(regex_format, str(var_value), node[key])
+                        result = re.sub(regex_format, str(var_value), result)
+                    node[key] = result
                 else:
-                    _traverse_yaml(value, variables)
-        elif isinstance(node, list):
-            for item in node:
-                _traverse_yaml(item, variables)
+                    node[key] = _traverse_yaml(value, variables)
+            return node
+        if isinstance(node, list):
+            return [_traverse_yaml(item, variables) for item in node]
+        if isinstance(node, str):
+            result = node
+            for var, var_value in variables.items():
+                regex_format = rf"\$\{{{var}\}}"
+                result = re.sub(regex_format, str(var_value), result)
+            return result
+        return node
 
     class IncludeLoader(yaml.SafeLoader):
         """YAML Loader with `!include` constructor."""
@@ -2598,34 +2606,54 @@ def safe_load_yaml(
             self._root = Path(stream.name).parent if hasattr(stream, "name") else Path.cwd()
             super().__init__(stream)
 
-    def _include(loader: IncludeLoader, node: yaml.nodes.Node) -> Any:
-        """Include file referenced at node."""
-        if isinstance(node.value, str):
-            filepath = loader._root / str(loader.construct_scalar(node))  # type: ignore[arg-type]
-            included_files.append(filepath)
-            with filepath.open(encoding=encoding) as included_file:
-                return yaml.load(
-                    included_file,
-                    lambda stream: IncludeLoader(stream),  # type: ignore[arg-type] # noqa: S506
-                )
-        else:
-            mapping = loader.construct_mapping(node, deep=True)  # type: ignore[arg-type]
-            assert mapping is not None
-            filepath = loader._root / str(mapping["file"])
-            included_files.append(filepath)
-            variables = mapping["vars"]
+        def _include(self, node: yaml.nodes.Node) -> Any:
+            """Include file referenced at node."""
+            if isinstance(node.value, str):
+                filepath = self._root / str(self.construct_scalar(node))  # type: ignore[arg-type]
+                included_files.append(filepath)
+                with filepath.open(encoding=encoding) as included_file:
+                    return yaml.load(
+                        included_file,
+                        lambda stream: IncludeLoader(stream),  # type: ignore[arg-type] # noqa: S506
+                    )
+            else:
+                mapping = self.construct_mapping(node, deep=True)  # type: ignore[arg-type]
+                assert mapping is not None
+                filepath = self._root / str(mapping["file"])
+                included_files.append(filepath)
+                variables = mapping["vars"]
 
-            with filepath.open(encoding=encoding) as included_file:
-                loaded_data = yaml.load(
-                    included_file,
-                    lambda stream: IncludeLoader(stream),  # type: ignore[arg-type] # noqa: S506
-                )
-                assert loaded_data is not None
-                assert variables is not None
-                _traverse_yaml(loaded_data, variables)
-                return loaded_data
+                with filepath.open(encoding=encoding) as included_file:
+                    loaded_data = yaml.load(
+                        included_file,
+                        lambda stream: IncludeLoader(stream),  # type: ignore[arg-type] # noqa: S506
+                    )
+                    assert loaded_data is not None
+                    assert variables is not None
+                    _traverse_yaml(loaded_data, variables)
+                    return loaded_data
 
-    IncludeLoader.add_constructor("!include", _include)
+        def construct_sequence(self, node: yaml.SequenceNode, deep: bool = False) -> Any:  # noqa: FBT001 FBT002
+            """Override sequence construction to flatten !include lists."""
+            result = []
+            for subnode in node.value:
+                if isinstance(subnode, yaml.ScalarNode) and subnode.tag == "!include":
+                    # Process !include directive
+                    loaded_data = self._include(subnode)
+                    if isinstance(loaded_data, list):
+                        result.extend(loaded_data)
+                    else:
+                        result.append(loaded_data)
+                else:
+                    # Handle non-include items
+                    constructed = self.construct_object(subnode, deep=deep)
+                    if isinstance(constructed, list):
+                        result.extend(constructed)
+                    else:
+                        result.append(constructed)
+            return result
+
+    IncludeLoader.add_constructor("!include", IncludeLoader._include)
     loaded_data = yaml.load(f, IncludeLoader)  # noqa: S506
     if return_included_paths:
         return loaded_data, included_files

--- a/home_assistant_streamdeck_yaml.py
+++ b/home_assistant_streamdeck_yaml.py
@@ -2576,7 +2576,7 @@ def safe_load_yaml(
     """Load a YAML file."""
     included_files = []
 
-    def _traverse_yaml(node: YamlNode, variables: dict[str, str]) -> Any:
+    def _traverse_yaml(node: YamlNode, variables: dict[str, str]) -> dict | list | str | YamlNode:
         if isinstance(node, dict):
             for key, value in node.items():
                 if isinstance(value, str):

--- a/tests/test_yaml.py
+++ b/tests/test_yaml.py
@@ -111,7 +111,7 @@ def test_include_file_paths(tmp_path: Path) -> None:
     assert set(included_files) == {included_file1, included_file2}
 
 
-def test_nested_include_with_file_path(tmp_path: Path) -> None:
+def test_nested_include(tmp_path: Path) -> None:
     """Test that safe_load_yaml handles nested !include directives correctly."""
     # Create directory structure
     includes_dir = tmp_path / "includes"

--- a/tests/test_yaml.py
+++ b/tests/test_yaml.py
@@ -171,3 +171,31 @@ name: Kitchen
         f"Included files do not match expected: {included_files}, "
         f"expected: {expected_included_files}"
     )
+
+
+def test_multiple_includes_in_list(tmp_path: Path) -> None:
+    """Test that safe_load_yaml handles multiple !include directives in a list correctly."""
+    # Create file1.yaml
+    file1_content = "- A\n- B\n"
+    file1_path = tmp_path / "file1.yaml"
+    file1_path.write_text(file1_content, encoding="utf-8")
+
+    # Create file2.yaml
+    file2_content = "- C\n- D\n"
+    file2_path = tmp_path / "file2.yaml"
+    file2_path.write_text(file2_content, encoding="utf-8")
+
+    # Create main.yaml
+    main_content = "- !include file1.yaml\n- !include file2.yaml\n"
+    main_path = tmp_path / "main.yaml"
+    main_path.write_text(main_content, encoding="utf-8")
+
+    # Load the main YAML file
+    with main_path.open(encoding="utf-8") as f:
+        result = safe_load_yaml(f)
+
+    # Expected output
+    expected = ["A", "B", "C", "D"]
+
+    # Assert the result matches the expected output
+    assert result == expected, f"Loaded data does not match expected: {result}"


### PR DESCRIPTION
(note, this is built on top of https://github.com/basnijholt/home-assistant-streamdeck-yaml/pull/278)

This pull request enhances the YAML loading functionality in `home_assistant_streamdeck_yaml.py` by improving handling of `!include` directives, adding support for nested includes, and introducing new test cases to validate these features. The most important changes include refactoring the `_traverse_yaml` function, modifying the `IncludeLoader` class to support nested and list-based `!include` directives, and adding comprehensive tests for these scenarios.

### Enhancements to YAML Loading:

* Refactored `_traverse_yaml` to handle YAML nodes more robustly, supporting dictionaries, lists, and strings while recursively processing variables. (`home_assistant_streamdeck_yaml.py`, [home_assistant_streamdeck_yaml.pyL2577-R2599](diffhunk://#diff-ee6ceda15b57b00671a56a2dae89dd10248cc8724840087ef89c6a501ef0333bL2577-R2599))
* Updated `IncludeLoader` to:
  - Support nested `!include` directives by overriding `construct_sequence` to flatten lists containing `!include`. 
  - Refactor `_include` to streamline file inclusion logic, ensuring proper handling of variables and encoding. (`home_assistant_streamdeck_yaml.py`, [home_assistant_streamdeck_yaml.pyL2601-R2656](diffhunk://#diff-ee6ceda15b57b00671a56a2dae89dd10248cc8724840087ef89c6a501ef0333bL2601-R2656))

### New Test Cases:

* Added `test_nested_include` to validate the correct handling of nested `!include` directives, ensuring the final loaded data matches the expected structure. (`tests/test_yaml.py`, [tests/test_yaml.pyR112-R201](diffhunk://#diff-b0c90097a466fcb03fb1eeda042c8603ab9ff62adaec89a90e872cba8426e96fR112-R201))
* Added `test_multiple_includes_in_list` to verify that multiple `!include` directives in a list are correctly flattened into a single list. (`tests/test_yaml.py`, [tests/test_yaml.pyR112-R201](diffhunk://#diff-b0c90097a466fcb03fb1eeda042c8603ab9ff62adaec89a90e872cba8426e96fR112-R201))