### PR TITLE
Update to readme. Render failed when light is off.

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,12 +462,8 @@ Here are >30 interesting uses for the Stream Deck with Home Assistant (click on 
     entity_id: light.living_room_lights
     brightness: >-
       {% set current = state_attr('light.living_room_lights', 'brightness') or 0 %}
-      {% set next = current - 25.5 %}
-      {% if next < 0 %}
-        0
-      {% else %}
-        {{ next | int }}
-      {% endif %}
+      {% set next = current + 25.5 %}
+      {{ [next, 255] | min | int }}
   text: >-
     {% set current_brightness = state_attr('light.living_room_lights', 'brightness') or 0 %}
     {% set brightness_pct = (current_brightness / 255) * 100 %}


### PR DESCRIPTION
I got "Render failed" when the light was off when using the "Control the brightness of a light (+10% on press)", so I had to account for that. After that I got an error with a min function so I ended up with this.