### PR TITLE
Fix websocket deprecation warning in test fixture

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -577,8 +577,8 @@ def test_generate_uniform_hex_colors() -> None:
 
 @pytest.fixture
 def websocket_mock() -> Mock:
-    """Mock websocket client protocol."""
-    return Mock(spec=websockets.WebSocketClientProtocol)
+    """Mock websocket client connection."""
+    return Mock(spec=websockets.ClientConnection)
 
 
 async def test_handle_key_press_toggle_light(


### PR DESCRIPTION
Updates the `websocket_mock` fixture in test_app.py to use `websockets.ClientConnection` instead of the deprecated `websockets.WebSocketClientProtocol`.

This was missed in #251.