### PR TITLE
Added detection of image format in _download_image function

### DIFF
--- a/home_assistant_streamdeck_yaml.py
+++ b/home_assistant_streamdeck_yaml.py
@@ -2826,6 +2826,14 @@ def _download_image(
     if image.mode != "RGB":
         image = image.convert("RGB")
     if filename is not None:
+        # If filename has no extension, add one based on the detected format
+        if filename.suffix == "":
+            # Determine format from the image, default to JPEG
+            fmt = image.format if image.format else "JPEG"
+            ext = fmt.lower()
+            if ext == "jpeg":
+                ext = "jpg"
+            filename = filename.with_suffix(f".{ext}")
         image.save(filename)
     return image.resize(size)
 


### PR DESCRIPTION
Sometimes the url in a media player's  entity_image attribute from Home Assistant does not have a file extension. This throws an error. 

I added a very small amount of code to the main .py file to fix this by detecting the image type and saving the file accordingly. This fixes the error noted in  issue #91.