### PR TITLE
Fix Docker workflow PR concurrency

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -10,7 +10,7 @@ on:
       - '*'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -26,6 +26,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Login to Docker Hub
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -37,4 +38,4 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           file: ./Dockerfile.locked
           platforms: linux/amd64,linux/arm64
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/home-assistant-streamdeck-yaml:latest
+          tags: basnijholt/home-assistant-streamdeck-yaml:latest


### PR DESCRIPTION
## Summary
- scope Docker workflow concurrency to each PR/ref instead of all pull_request runs
- skip Docker Hub login for pull requests because PR builds do not push
- use the public Docker image tag directly so PR builds do not depend on Docker Hub secrets

## Verification
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/docker-build.yml`
- `yq eval . .github/workflows/docker-build.yml`
- `git diff --check`