### PR TITLE
Fix Docker image when /app is bind-mounted

### DIFF
--- a/Dockerfile.latest
+++ b/Dockerfile.latest
@@ -6,16 +6,19 @@ USER root
 
 # Install unidep and git
 RUN micromamba install --name base --channel conda-forge --yes unidep git
-WORKDIR /app
+WORKDIR /opt/home-assistant-streamdeck-yaml
 
 # Copy the dependencies file for pip
-COPY . /app/
-COPY .git /app/.git
+COPY . /opt/home-assistant-streamdeck-yaml/
+COPY .git /opt/home-assistant-streamdeck-yaml/.git
 
 # Install the required dependencies
 RUN micromamba run \
     unidep install -e . && \
     micromamba clean --all --yes
+
+WORKDIR /app
+ENV STREAMDECK_CONFIG=/app/configuration.yaml
 
 # Set the entrypoint
 CMD ["home-assistant-streamdeck-yaml"]

--- a/Dockerfile.locked
+++ b/Dockerfile.locked
@@ -4,10 +4,10 @@ FROM mambaorg/micromamba:lunar
 # Run the container as root to get access to the USB devices
 USER root
 
-WORKDIR /app
+WORKDIR /opt/home-assistant-streamdeck-yaml
 
 # Install the dependencies from the lock file
-COPY conda-lock.yml /app/conda-lock.yml
+COPY conda-lock.yml /opt/home-assistant-streamdeck-yaml/conda-lock.yml
 RUN micromamba install --name base --file conda-lock.yml
 
 # Install git
@@ -15,12 +15,15 @@ RUN micromamba install --name base --channel conda-forge --yes git && \
     micromamba clean --all --yes
 
 # Copy the rest of the files
-COPY . /app/
-COPY .git /app/.git
+COPY . /opt/home-assistant-streamdeck-yaml/
+COPY .git /opt/home-assistant-streamdeck-yaml/.git
 
 # Install home-assistant-streamdeck-yaml
 RUN micromamba run \
     pip install --no-deps -e .
+
+WORKDIR /app
+ENV STREAMDECK_CONFIG=/app/configuration.yaml
 
 # Set the entrypoint
 CMD ["home-assistant-streamdeck-yaml"]

--- a/tests/test_dockerfiles.py
+++ b/tests/test_dockerfiles.py
@@ -2,7 +2,6 @@
 
 from pathlib import Path
 
-
 ROOT = Path(__file__).resolve().parents[1]
 DOCKERFILES = ("Dockerfile.latest", "Dockerfile.locked")
 APP_SOURCE_DIR = "/opt/home-assistant-streamdeck-yaml"

--- a/tests/test_dockerfiles.py
+++ b/tests/test_dockerfiles.py
@@ -1,0 +1,28 @@
+"""Regression tests for Docker image layout."""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DOCKERFILES = ("Dockerfile.latest", "Dockerfile.locked")
+APP_SOURCE_DIR = "/opt/home-assistant-streamdeck-yaml"
+RUNTIME_CONFIG = "/app/configuration.yaml"
+
+
+def test_docker_images_install_application_outside_user_config_mount() -> None:
+    """Bind-mounting user config onto /app must not hide the installed module."""
+    for dockerfile in DOCKERFILES:
+        text = (ROOT / dockerfile).read_text()
+
+        assert f"WORKDIR {APP_SOURCE_DIR}" in text, dockerfile
+        assert f"COPY . {APP_SOURCE_DIR}/" in text, dockerfile
+        assert f"COPY .git {APP_SOURCE_DIR}/.git" in text, dockerfile
+
+
+def test_docker_images_default_to_mounted_configuration() -> None:
+    """The documented Docker command mounts configuration.yaml into /app."""
+    for dockerfile in DOCKERFILES:
+        text = (ROOT / dockerfile).read_text()
+
+        assert f"ENV STREAMDECK_CONFIG={RUNTIME_CONFIG}" in text, dockerfile
+        assert "WORKDIR /app" in text, dockerfile


### PR DESCRIPTION
## Summary
- Install the package source from `/opt/home-assistant-streamdeck-yaml` inside Docker images so bind-mounting user config onto `/app` does not hide the editable module.
- Keep `/app` as the runtime workdir and set `STREAMDECK_CONFIG=/app/configuration.yaml` for the documented Docker usage.
- Add regression coverage for the Dockerfile layout.

Fixes #324.

## Test Plan
- `DYLD_LIBRARY_PATH=/opt/homebrew/lib .venv311/bin/python -m pytest` (130 passed, 1 skipped)
- `docker build --check -f Dockerfile.latest .`
- `docker build --check -f Dockerfile.locked .`
- `docker build -f Dockerfile.locked -t hasdy-issue-324-test .`
- `docker run --rm -v "$tmpdir:/app" hasdy-issue-324-test home-assistant-streamdeck-yaml --help`
- `docker run --rm -v "$tmpdir:/app" hasdy-issue-324-test sh -lc 'pwd && printf "%s\n" "$STREAMDECK_CONFIG"'`
