### PR TITLE
Refresh URL icons on each render

### DIFF
--- a/home_assistant_streamdeck_yaml.py
+++ b/home_assistant_streamdeck_yaml.py
@@ -375,7 +375,7 @@ class Button(_ButtonDialBase, extra="forbid"):  # type: ignore[call-arg]
             if which == "url":
                 filename = _url_to_filename(id_)
                 # copy to avoid modifying the cached image
-                image = _download_image(id_, filename, size).copy()
+                image = _download_image(id_, filename, size, force_download=True).copy()
             if which == "ring":
                 pct = _maybe_number(id_)
                 assert isinstance(pct, (int, float)), f"Invalid ring percentage: {id_}"
@@ -720,7 +720,7 @@ class Dial(_ButtonDialBase, extra="forbid"):  # type: ignore[call-arg]
                     image = _download_spotify_image(id_, filename).copy()
                 elif which == "url":
                     filename = _url_to_filename(id_)
-                    image = _download_image(id_, filename, size).copy()
+                    image = _download_image(id_, filename, size, force_download=True).copy()
                 elif which == "ring":
                     pct = _maybe_number(id_)
                     assert isinstance(
@@ -2636,6 +2636,11 @@ async def _try_handle_key_press(
 
 @ft.lru_cache(maxsize=128)
 def _download(url: str) -> bytes:
+    """Download the content from the URL, cached by URL."""
+    return _download_uncached(url)
+
+
+def _download_uncached(url: str) -> bytes:
     """Download the content from the URL."""
     console.log(f"Downloading {url}")
     response = requests.get(url, timeout=5)
@@ -2810,18 +2815,19 @@ def _download_spotify_image(
     return _download_image(image_url, filename, size)
 
 
-@ft.lru_cache(maxsize=32)  # Change only a few images, because they might be large
 def _download_image(
     url: str,
     filename: Path | None = None,
     size: tuple[int, int] = (ICON_PIXELS, ICON_PIXELS),
+    *,
+    force_download: bool = False,
 ) -> Image.Image:
     """Download an image for a given url."""
-    if filename is not None and filename.exists():
+    if not force_download and filename is not None and filename.exists():
         image = Image.open(filename)
         # To correctly size after getting from file
         return image.resize(size)
-    image_content = _download(url)
+    image_content = _download_uncached(url) if force_download else _download(url)
     image = Image.open(io.BytesIO(image_content))
     if image.mode != "RGB":
         image = image.convert("RGB")

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import functools as ft
+import io
 import json
 import sys
 import textwrap
@@ -22,10 +23,12 @@ from websockets.exceptions import ConnectionClosedError  # noqa: F401
 from home_assistant_streamdeck_yaml import (
     ASSETS_PATH,
     DEFAULT_CONFIG,
+    ICON_PIXELS,
     Button,
     Config,
     IconWarning,
     Page,
+    _download,
     _download_and_save_mdi,
     _download_spotify_image,
     _generate_uniform_hex_colors,
@@ -459,6 +462,36 @@ def test_download_spotify_image() -> None:
     filename = _to_filename(icon, ".jpeg")
     _download_spotify_image(icon, filename)
     assert filename.exists()
+
+
+def test_url_icon_refreshes_on_render(tmp_path: Path) -> None:
+    """URL icons should be re-downloaded when the button is rendered again."""
+
+    def png_bytes(color: tuple[int, int, int]) -> bytes:
+        image = Image.new("RGB", (ICON_PIXELS, ICON_PIXELS), color)
+        buffer = io.BytesIO()
+        image.save(buffer, format="PNG")
+        return buffer.getvalue()
+
+    responses = [Mock(content=png_bytes((255, 0, 0))), Mock(content=png_bytes((0, 255, 0)))]
+    expected_downloads = len(responses)
+    cached_file = tmp_path / "album.png"
+    button = Button(icon="url:https://example.com/local/images/album.jpg")
+
+    _download.cache_clear()
+    with (
+        patch("home_assistant_streamdeck_yaml._url_to_filename", return_value=cached_file),
+        patch(
+            "home_assistant_streamdeck_yaml.requests.get",
+            side_effect=responses,
+        ) as get,
+    ):
+        first = button.render_icon({})
+        second = button.render_icon({})
+
+    assert get.call_count == expected_downloads
+    assert first.getpixel((0, 0)) == (255, 0, 0)
+    assert second.getpixel((0, 0)) == (0, 255, 0)
 
 
 def test_is_state_attr(state: dict[str, dict[str, Any]]) -> None:


### PR DESCRIPTION
## Summary
- Re-download `url:` icons whenever a button or dial is rendered so state-change updates can pick up dynamic remote images.
- Keep cached downloads for other call paths, including Spotify/MDI-style static assets.
- Add a regression test that renders the same `url:` icon twice and verifies the second render uses fresh image bytes.

Fixes #317.

## Test Plan
- `DYLD_LIBRARY_PATH=/opt/homebrew/lib .venv311/bin/python -m pytest` (131 passed, 1 skipped)
- `.venv311/bin/pre-commit run --all-files`
